### PR TITLE
Compilation config out to be available on headers path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@ Makefile.in
 *.la
 config.status
 config.guess
-config.h
-config.h.in
+/include/freerdp/config.h
+/include/freerdp/config.h.in
 config.log
 config.sub
 configure

--- a/X11/xf_types.h
+++ b/X11/xf_types.h
@@ -24,7 +24,7 @@
 #include <freerdp/chanman.h>
 #include <X11/Xlib.h>
 
-#include <config.h>
+#include <freerdp/config.h>
 
 #define SET_XFI(_inst, _xfi) (_inst)->param1 = _xfi
 #define GET_XFI(_inst) ((xfInfo *) ((_inst)->param1))

--- a/X11/xf_types.h
+++ b/X11/xf_types.h
@@ -24,9 +24,7 @@
 #include <freerdp/chanman.h>
 #include <X11/Xlib.h>
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include <config.h>
 
 #define SET_XFI(_inst, _xfi) (_inst)->param1 = _xfi
 #define GET_XFI(_inst) ((xfInfo *) ((_inst)->param1))

--- a/asn1/Makefile.am
+++ b/asn1/Makefile.am
@@ -260,7 +260,7 @@ libasn1_la_SOURCES = \
 	$(spnego_sources)
 #	$(mcs_sources)
 
-libasn1_la_CFLAGS = -O2 -w
+libasn1_la_CFLAGS = -O2 -w -I. -I$(top_srcdir)/include
 
 libasn1_la_LDFLAGS = -avoid-version -module
 

--- a/asn1/asn_system.h
+++ b/asn1/asn_system.h
@@ -9,9 +9,7 @@
 #ifndef	_ASN_SYSTEM_H_
 #define	_ASN_SYSTEM_H_
 
-#ifdef	HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include <config.h>
 
 #include <stdio.h>	/* For snprintf(3) */
 #include <stdlib.h>	/* For *alloc(3) */

--- a/asn1/asn_system.h
+++ b/asn1/asn_system.h
@@ -9,7 +9,7 @@
 #ifndef	_ASN_SYSTEM_H_
 #define	_ASN_SYSTEM_H_
 
-#include <config.h>
+#include <freerdp/config.h>
 
 #include <stdio.h>	/* For snprintf(3) */
 #include <stdlib.h>	/* For *alloc(3) */

--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -39,7 +39,7 @@ scriptversion=2010-02-24.17; # UTC
 #
 # .version - present in a checked-out repository and in a distribution
 #   tarball.  Usable in dependencies, particularly for files that don't
-#   want to depend on config.h but do want to track version changes.
+#   want to depend on freerdp/config.h but do want to track version changes.
 #   Delete this file prior to any autoconf run where you want to rebuild
 #   files to pick up a version string change; and leave it stale to
 #   minimize rebuild time after unrelated changes to configure sources.

--- a/channels/cliprdr/cliprdr_x11.c
+++ b/channels/cliprdr/cliprdr_x11.c
@@ -23,7 +23,7 @@
    http://msdn.microsoft.com/en-us/library/ff468800%28v=VS.85%29.aspx
 */
 
-#include <config.h>
+#include <freerdp/config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/channels/cliprdr/cliprdr_x11.c
+++ b/channels/cliprdr/cliprdr_x11.c
@@ -23,7 +23,7 @@
    http://msdn.microsoft.com/en-us/library/ff468800%28v=VS.85%29.aspx
 */
 
-#include "config.h"
+#include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/channels/common/chan_stream.c
+++ b/channels/common/chan_stream.c
@@ -17,7 +17,7 @@
    limitations under the License.
 */
 
-#include "config.h"
+#include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/channels/common/chan_stream.c
+++ b/channels/common/chan_stream.c
@@ -17,7 +17,7 @@
    limitations under the License.
 */
 
-#include <config.h>
+#include <freerdp/config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/channels/rdpdr/devman.c
+++ b/channels/rdpdr/devman.c
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <config.h>
+#include <freerdp/config.h>
 #include "rdpdr_types.h"
 #include "rdpdr_constants.h"
 #include "devman.h"

--- a/channels/rdpdr/devman.c
+++ b/channels/rdpdr/devman.c
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "config.h"
+#include <config.h>
 #include "rdpdr_types.h"
 #include "rdpdr_constants.h"
 #include "devman.h"

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_INIT(freerdp, m4_esyscmd([build-aux/git-version-gen .tarball-version]),
         [freerdp-devel@lists.sourceforge.net])
 AM_INIT_AUTOMAKE([1.11 dist-xz color-tests parallel-tests])
 AM_SILENT_RULES([yes]) # make --enable-silent-rules the default.
-AM_CONFIG_HEADER([config.h])
+AM_CONFIG_HEADER([include/freerdp/config.h])
 AC_CONFIG_SRCDIR([libfreerdp/freerdp.c])
 
 AC_PROG_CC

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -2,6 +2,7 @@
 
 includedir = $(prefix)/include/freerdp
 include_HEADERS = \
+	freerdp/config.h \
 	freerdp/constants_ui.h \
 	freerdp/constants_vchan.h \
 	freerdp/freerdp.h \

--- a/libfreerdp/debug.h
+++ b/libfreerdp/debug.h
@@ -1,7 +1,7 @@
 #ifndef __DEBUG_H
 #define __DEBUG_H
 
-#include <config.h>
+#include <freerdp/config.h>
 
 #ifdef WITH_DEBUG_ASSERT
 #include <assert.h>

--- a/libfreerdp/debug.h
+++ b/libfreerdp/debug.h
@@ -1,9 +1,7 @@
 #ifndef __DEBUG_H
 #define __DEBUG_H
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include <config.h>
 
 #ifdef WITH_DEBUG_ASSERT
 #include <assert.h>

--- a/libfreerdp/frdp.h
+++ b/libfreerdp/frdp.h
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <config.h>
+#include <freerdp/config.h>
 
 #include "types.h"
 

--- a/libfreerdp/frdp.h
+++ b/libfreerdp/frdp.h
@@ -23,9 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+#include <config.h>
 
 #include "types.h"
 

--- a/win/wfreerdp/wfreerdp.cpp
+++ b/win/wfreerdp/wfreerdp.cpp
@@ -24,9 +24,7 @@
 #include <sys/types.h>
 #include <errno.h>
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <freerdp/freerdp.h>
 #include <freerdp/chanman.h>

--- a/win/wfreerdp/wfreerdp.cpp
+++ b/win/wfreerdp/wfreerdp.cpp
@@ -24,7 +24,7 @@
 #include <sys/types.h>
 #include <errno.h>
 
-#include <config.h>
+#include <freerdp/config.h>
 
 #include <freerdp/freerdp.h>
 #include <freerdp/chanman.h>

--- a/wireshark/packet-rdp.c
+++ b/wireshark/packet-rdp.c
@@ -23,9 +23,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#ifdef HAVE_CONFIG_H
-# include "config.h"
-#endif
+#include <config.h>
 
 #include <glib.h>
 #include <epan/packet.h>

--- a/wireshark/packet-rdp.c
+++ b/wireshark/packet-rdp.c
@@ -23,7 +23,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#include <config.h>
+#include <freerdp/config.h>
 
 #include <glib.h>
 #include <epan/packet.h>


### PR DESCRIPTION
It is common to write code that depends on a feature to be available. In this case, FreeRDP needs to install the config.h header  together with other library headers to allow applications to know if something is available for usage or not.

This change can potentially break Windows builds since as far as I know, nothing writes a similar file for it.
