### PR TITLE
Unicode

### DIFF
--- a/include/freerdp/freerdp.h
+++ b/include/freerdp/freerdp.h
@@ -77,6 +77,7 @@ struct rdp_inst
 	int (* rdp_send_input_scancode)(rdpInst * inst, RD_BOOL up, RD_BOOL extended, uint8 keyCode);
 	int (* rdp_send_input_mouse)(rdpInst * inst, uint16 pointerFlags, uint16 xPos, uint16 yPos);
 	int (* rdp_sync_input)(rdpInst * inst, int toggle_flags);
++	int (* rdp_unicode_input)(rdpInst * inst, uint16 character);
 	int (* rdp_channel_data)(rdpInst * inst, int chan_id, char * data, int data_size);
 	void (* rdp_disconnect)(rdpInst * inst);
 	int (* rdp_send_frame_ack)(rdpInst * inst, int frame_id);

--- a/libfreerdp/freerdp.c
+++ b/libfreerdp/freerdp.c
@@ -453,6 +453,7 @@ ui_check_certificate(rdpInst * inst, const char * fingerprint,
 static int
 l_rdp_connect(rdpInst * inst)
 {
+    printf("l_rdp_connect\n");
 	rdpRdp * rdp;
 	int index;
 
@@ -535,6 +536,16 @@ l_rdp_send_input_mouse(rdpInst * inst, uint16 pointerFlags, uint16 xPos, uint16 
 	return 0;
 }
 
+// ADD:
+static int
+l_rdp_unicode_input(rdpInst * inst, uint16 character)
+{
+	rdpRdp * rdp;
+	rdp = RDP_FROM_INST(inst);
+	rdp_unicode_input(rdp, time(NULL), character);
+	return 0;
+}
+
 static int
 l_rdp_sync_input(rdpInst * inst, int toggle_flags)
 {
@@ -599,6 +610,7 @@ freerdp_new(rdpSet * settings)
 	inst->rdp_check_fds = l_rdp_check_fds;
 	inst->rdp_send_input_scancode = l_rdp_send_input_scancode;
 	inst->rdp_send_input_mouse = l_rdp_send_input_mouse;
+	inst->rdp_unicode_input = l_rdp_unicode_input;
 	inst->rdp_sync_input = l_rdp_sync_input;
 	inst->rdp_channel_data = l_rdp_channel_data;
 	inst->rdp_disconnect = l_rdp_disconnect;

--- a/libfreerdp/freerdp.c
+++ b/libfreerdp/freerdp.c
@@ -453,7 +453,6 @@ ui_check_certificate(rdpInst * inst, const char * fingerprint,
 static int
 l_rdp_connect(rdpInst * inst)
 {
-    printf("l_rdp_connect\n");
 	rdpRdp * rdp;
 	int index;
 
@@ -536,7 +535,6 @@ l_rdp_send_input_mouse(rdpInst * inst, uint16 pointerFlags, uint16 xPos, uint16 
 	return 0;
 }
 
-// ADD:
 static int
 l_rdp_unicode_input(rdpInst * inst, uint16 character)
 {


### PR DESCRIPTION
I don't know if you plan to add unicode support to FreeRDP, but I'm currently using the rdp_unicode_input function to send characters from an iPad with success.

You may prefer enable this feature by adding a flag in the configure script, if so, this pull request is useless.
