### PR TITLE
Client name option for redirecting devices

### DIFF
--- a/channels/rdpdr/rdpdr_main.h
+++ b/channels/rdpdr/rdpdr_main.h
@@ -55,6 +55,7 @@ struct rdpdr_plugin
 	uint16 versionMinor;
 	uint16 clientID;
 	DEVMAN* devman;
+	char computerName[256];
 
 	/* Async IO stuff */
 	IRPQueue * queue;


### PR DESCRIPTION
The command line would be something like that:

xfreerdp -n LiverpoolFC  --plugin rdpdr --data disk:THEFA:/home/beloni/folder --data clientname:LiverpoolFC -- win7

I just wonder how would be the man page to reflect this change...
