### PR TITLE
libfreerdp-gdi: change gdi_copy_mem to simply use memcpy for better performance 

### DIFF
--- a/libfreerdp-gdi/gdi.c
+++ b/libfreerdp-gdi/gdi.c
@@ -311,23 +311,7 @@ gdi_rop3_code(uint8 code)
 void
 gdi_copy_mem(uint8 * d, uint8 * s, int n)
 {
-	while (n & (~7))
-	{
-		*(d++) = *(s++);
-		*(d++) = *(s++);
-		*(d++) = *(s++);
-		*(d++) = *(s++);
-		*(d++) = *(s++);
-		*(d++) = *(s++);
-		*(d++) = *(s++);
-		*(d++) = *(s++);
-		n = n - 8;
-	}
-	while (n > 0)
-	{
-		*(d++) = *(s++);
-		n--;
-	}
+	memcpy(d, s, n);
 }
 
 void


### PR DESCRIPTION
libfreerdp-gdi: change gdi_copy_mem to simply use memcpy for better performance

gdi_copy_mem is a performance critical region, called for each scanline in many
graphics routines. This patch changes it to simply call memcpy, which is far
faster than a naive c loop. More performance could be squeezed out thru other
methods, but this is low hanging fruit with no adverse affects or compilation
requirements.
