### PR TITLE
libfreerdp-core: When server orders a screen bpp change, call ui_resize_window 

### DIFF
--- a/X11/xf_win.c
+++ b/X11/xf_win.c
@@ -787,6 +787,14 @@ l_ui_reset_clip(struct rdp_inst * inst)
 static void
 l_ui_resize_window(struct rdp_inst * inst)
 {
+	xfInfo * xfi = GET_XFI(inst);
+
+	if (xfi->settings->software_gdi == 1)
+	{
+		gdi_free(inst);
+		gdi_init(inst, CLRCONV_ALPHA | CLRBUF_32BPP);		
+	}
+	
 	printf("ui_resize_window:\n");
 }
 

--- a/libfreerdp-core/capabilities.c
+++ b/libfreerdp-core/capabilities.c
@@ -168,6 +168,7 @@ void rdp_process_bitmap_capset(rdpRdp * rdp, STREAM s)
 		ui_warning(rdp->inst, "Remote desktop does not support color depth %d; falling back to %d\n",
 			rdp->settings->server_depth, preferredBitsPerPixel);
 		rdp->settings->server_depth = preferredBitsPerPixel;
+		ui_resize_window(rdp->inst);
 	}
 	if (rdp->settings->width != desktopWidth || rdp->settings->height != desktopHeight)
 	{

--- a/libfreerdp-gdi/gdi.c
+++ b/libfreerdp-gdi/gdi.c
@@ -1202,4 +1202,6 @@ void gdi_free(rdpInst* inst)
 		free(gdi->clrconv);
 		free(gdi);
 	}
+	
+	SET_GDI(inst, NULL);
 }


### PR DESCRIPTION
xfreerdp-core: When server orders a screen bpp change, call ui_resize_window

Some servers are configured to limit connections to 16bpp, and send a
rdp_process_bitmap_capset to enforce it. UI ports need a chance to
reallocate buffers based on this info. This patch makes xfreerdp in
sw rendering mode re-allocate the GDI object, so that these sessions
work properly.

Note: I'm submitting small patches right now while I'm getting used to the FreeRDP policies; please LMK if I'm doing anything strange. I'll start to group my commits when I get a little more confident.
- dorian
