### PR TITLE
core network refactoring

### DIFF
--- a/channels/drdynvc/drdynvc_main.c
+++ b/channels/drdynvc/drdynvc_main.c
@@ -28,6 +28,7 @@
 #include <freerdp/utils/stream.h>
 #include <freerdp/utils/chan_plugin.h>
 #include <freerdp/utils/wait_obj.h>
+#include <freerdp/utils/hexdump.h>
 
 #include "drdynvc_main.h"
 
@@ -72,43 +73,9 @@ struct drdynvc_plugin
 };
 
 #if LOG_LEVEL > 10
-void
-hexdump(char* p, int len)
-{
-	unsigned char* line;
-	int i;
-	int thisline;
-	int offset;
-
-	line = (unsigned char*)p;
-	offset = 0;
-	while (offset < len)
-	{
-		printf("%04x ", offset);
-		thisline = len - offset;
-		if (thisline > 16)
-		{
-		  thisline = 16;
-		}
-		for (i = 0; i < thisline; i++)
-		{
-		  printf("%02x ", line[i]);
-		}
-		for (; i < 16; i++)
-		{
-		  printf("   ");
-		}
-		for (i = 0; i < thisline; i++)
-		{
-		  printf("%c", (line[i] >= 0x20 && line[i] < 0x7f) ? line[i] : '.');
-		}
-		printf("\n");
-		offset += thisline;
-		line += thisline;
-	}
-}
+#define hexdump(data,length)	freerdp_hexdump(data,length)
 #else
-#define hexdump(p,len)
+#define hexdump(data,length)	do { } while (0)
 #endif
 
 static int

--- a/include/freerdp/types/base.h
+++ b/include/freerdp/types/base.h
@@ -23,6 +23,11 @@
 #ifndef __TYPES_BASE_H
 #define __TYPES_BASE_H
 
+#ifndef True
+#define True  (1)
+#define False (0)
+#endif
+
 typedef unsigned char uint8;
 typedef signed char sint8;
 typedef unsigned short uint16;

--- a/include/freerdp/types/ui.h
+++ b/include/freerdp/types/ui.h
@@ -31,11 +31,6 @@ typedef void *RD_HGLYPH;
 typedef void *RD_HPALETTE;
 typedef void *RD_HCURSOR;
 
-#ifndef True
-#define True  (1)
-#define False (0)
-#endif
-
 typedef struct _RD_POINT
 {
 	sint16 x, y;

--- a/include/freerdp/utils/Makefile.am
+++ b/include/freerdp/utils/Makefile.am
@@ -11,4 +11,5 @@ include_HEADERS = \
 	stopwatch.h \
 	stream.h \
 	unicode.h \
-	wait_obj.h
+	wait_obj.h \
+	hexdump.h

--- a/include/freerdp/utils/hexdump.h
+++ b/include/freerdp/utils/hexdump.h
@@ -1,0 +1,27 @@
+/*
+   FreeRDP: A Remote Desktop Protocol client.
+   Hex Dump Utils
+
+   Copyright 2011 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef __UTILS_HEXDUMP_H
+#define __UTILS_HEXDUMP_H
+
+#define FREERDP_HEXDUMP_LINE_LENGTH	16
+
+void freerdp_hexdump(uint8* data, int length);
+
+#endif /* __UTILS_HEXDUMP_H */

--- a/libfreerdp-core/Makefile.am
+++ b/libfreerdp-core/Makefile.am
@@ -23,6 +23,7 @@ libfreerdp_core_la_SOURCES = \
 	rail.c rail.h \
 	rdp.c rdp.h \
 	secure.c secure.h \
+	network.c network.h \
 	crypto.h \
 	tcp.c tcp.h \
 	nego.c nego.h \

--- a/libfreerdp-core/Makefile.am
+++ b/libfreerdp-core/Makefile.am
@@ -10,6 +10,7 @@ libfreerdp_core_la_SOURCES = \
 	bitmap.c bitmap.h \
 	cache.c cache.h \
 	capabilities.c capabilities.h \
+	connect.c connect.h \
 	chan.c chan.h \
 	ext.c ext.h \
 	freerdp.c \
@@ -22,7 +23,7 @@ libfreerdp_core_la_SOURCES = \
 	pstcache.c pstcache.h \
 	rail.c rail.h \
 	rdp.c rdp.h \
-	secure.c secure.h \
+	security.c security.h \
 	network.c network.h \
 	crypto.h \
 	tcp.c tcp.h \

--- a/libfreerdp-core/asn1.c
+++ b/libfreerdp-core/asn1.c
@@ -42,7 +42,7 @@ ber_parse_header(rdpMcs * mcs, STREAM s, int tagval, int *length)
 
 	if (tag != tagval)
 	{
-		ui_error(mcs->sec->rdp->inst, "expected tag %d, got %d\n", tagval, tag);
+		ui_error(mcs->net->rdp->inst, "expected tag %d, got %d\n", tagval, tag);
 		return False;
 	}
 

--- a/libfreerdp-core/asn1.c
+++ b/libfreerdp-core/asn1.c
@@ -21,9 +21,9 @@
 #include "iso.h"
 #include "mcs.h"
 #include "chan.h"
-#include "secure.h"
 #include "rdp.h"
 #include "asn1.h"
+#include "security.h"
 
 /* Parse an ASN.1 BER header */
 RD_BOOL

--- a/libfreerdp-core/chan.c
+++ b/libfreerdp-core/chan.c
@@ -20,8 +20,8 @@
 #include "frdp.h"
 #include "chan.h"
 #include "mcs.h"
-#include "secure.h"
 #include "rdp.h"
+#include "security.h"
 #include <freerdp/rdpset.h>
 #include <freerdp/utils/memory.h>
 #include <freerdp/constants/vchan.h>

--- a/libfreerdp-core/chan.c
+++ b/libfreerdp-core/chan.c
@@ -38,11 +38,11 @@ vchan_send(rdpChannels * chan, int mcs_id, char * data, int total_length)
 	rdpSet * settings;
 	struct rdp_chan * channel;
 
-	settings = chan->mcs->sec->rdp->settings;
+	settings = chan->mcs->net->rdp->settings;
 	chan_index = (mcs_id - MCS_GLOBAL_CHANNEL) - 1;
 	if ((chan_index < 0) || (chan_index >= settings->num_channels))
 	{
-		ui_error(chan->mcs->sec->rdp->inst, "error\n");
+		ui_error(chan->mcs->net->rdp->inst, "error\n");
 		return 0;
 	}
 	channel = &(settings->channels[chan_index]);
@@ -61,12 +61,12 @@ vchan_send(rdpChannels * chan, int mcs_id, char * data, int total_length)
 		{
 			chan_flags |= CHANNEL_FLAG_SHOW_PROTOCOL;
 		}
-		s = sec_init(chan->mcs->sec, sec_flags, length + 8);
+		s = sec_init(chan->mcs->net->sec, sec_flags, length + 8);
 		out_uint32_le(s, total_length);
 		out_uint32_le(s, chan_flags);
 		out_uint8p(s, data + sent, length);
 		s_mark_end(s);
-		sec_send_to_channel(chan->mcs->sec, s, sec_flags, mcs_id);
+		sec_send_to_channel(chan->mcs->net->sec, s, sec_flags, mcs_id);
 		sent += length;
 		chan_flags = 0;
 	}
@@ -86,7 +86,7 @@ vchan_process(rdpChannels * chan, STREAM s, int mcs_id)
 	length = (int) (s->end - s->p);
 	data = (char *) (s->p);
 	s->p += length;
-	ui_channel_data(chan->mcs->sec->rdp->inst, mcs_id, data, length, flags, total_length);
+	ui_channel_data(chan->mcs->net->sec->rdp->inst, mcs_id, data, length, flags, total_length);
 }
 
 rdpChannels *

--- a/libfreerdp-core/chan.h
+++ b/libfreerdp-core/chan.h
@@ -21,6 +21,7 @@
 #define __CHAN_H
 
 #include "mcs.h"
+#include "network.h"
 
 struct rdp_channels
 {

--- a/libfreerdp-core/connect.c
+++ b/libfreerdp-core/connect.c
@@ -1,8 +1,8 @@
 /*
    FreeRDP: A Remote Desktop Protocol client.
-   RDP encryption and licensing
+   Connection Sequence
 
-   Copyright (C) Matthew Chapman 1999-2008
+   Copyright 2011 Marc-Andre Moreau <marcandre.moreau@gmail.com>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,381 +17,25 @@
    limitations under the License.
 */
 
-#include "frdp.h"
-#include "mcs.h"
-#include "chan.h"
-#include "license.h"
 #include "rdp.h"
-#include "iso.h"
-#include "tcp.h"
+#include "nego.h"
+#include "security.h"
 #include <freerdp/rdpset.h>
+#include <freerdp/freerdp.h>
 #include <freerdp/utils/memory.h>
+#include <freerdp/utils/unicode.h>
 
-#ifndef DISABLE_TLS
-#include "tls.h"
-#include "credssp.h"
-#endif
-
-#include "secure.h"
-
-static RD_BOOL sec_global_initialized = False;
-
-RD_BOOL
-sec_global_init(void)
-{
-	if (!sec_global_initialized)
-	{
-		sec_global_initialized = crypto_global_init();
-	}
-	return sec_global_initialized;
-}
-
-void
-sec_global_finish(void)
-{
-	crypto_global_finish();
-	sec_global_initialized = False;
-}
-
-/* these are read only */
-static uint8 pad_54[40] = {
-	54, 54, 54, 54, 54, 54, 54, 54,
-	54, 54, 54, 54, 54, 54, 54, 54,
-	54, 54, 54, 54, 54, 54, 54, 54,
-	54, 54, 54, 54, 54, 54, 54, 54,
-	54, 54, 54, 54, 54, 54, 54, 54
-};
-
-static uint8 pad_92[48] = {
-	92, 92, 92, 92, 92, 92, 92, 92,
-	92, 92, 92, 92, 92, 92, 92, 92,
-	92, 92, 92, 92, 92, 92, 92, 92,
-	92, 92, 92, 92, 92, 92, 92, 92,
-	92, 92, 92, 92, 92, 92, 92, 92,
-	92, 92, 92, 92, 92, 92, 92, 92
-};
-
-/*
- * 48-byte transformation used to generate master secret (6.1) and key material (6.2.2).
- * Both SHA1 and MD5 algorithms are used.
- */
-void
-sec_hash_48(uint8 * out, uint8 * in, uint8 * salt1, uint8 * salt2, uint8 salt)
-{
-	int i;
-	uint8 pad[4];
-	uint8 shasig[20];
-	CryptoMd5 md5;
-	CryptoSha1 sha1;
-
-	for (i = 0; i < 3; i++)
-	{
-		memset(pad, salt + i, i + 1);
-
-		sha1 = crypto_sha1_init();
-		crypto_sha1_update(sha1, pad, i + 1);
-		crypto_sha1_update(sha1, in, 48);
-		crypto_sha1_update(sha1, salt1, 32);
-		crypto_sha1_update(sha1, salt2, 32);
-		crypto_sha1_final(sha1, shasig);
-
-		md5 = crypto_md5_init();
-		crypto_md5_update(md5, in, 48);
-		crypto_md5_update(md5, shasig, 20);
-		crypto_md5_final(md5, &out[i * 16]);
-	}
-}
-
-/*
- * 16-byte transformation used to generate export keys (6.2.2).
- */
-void
-sec_hash_16(uint8 * out, uint8 * in, uint8 * salt1, uint8 * salt2)
-{
-	CryptoMd5 md5 = crypto_md5_init();
-	crypto_md5_update(md5, in, 16);
-	crypto_md5_update(md5, salt1, 32);
-	crypto_md5_update(md5, salt2, 32);
-	crypto_md5_final(md5, out);
-}
-
-/* Reduce key entropy from 64 to 40 bits */
-static void
-sec_make_40bit(uint8 * key)
-{
-	key[0] = 0xd1;
-	key[1] = 0x26;
-	key[2] = 0x9e;
-}
-
-/* Generate encryption keys given client and server randoms */
-static void
-sec_generate_keys(rdpSec * sec, uint8 * client_random, uint8 * server_random, int rc4_key_size)
-{
-	uint8 pre_master_secret[48];
-	uint8 master_secret[48];
-	uint8 key_block[48];
-
-	/* Construct pre-master secret */
-	memcpy(pre_master_secret, client_random, 24);
-	memcpy(pre_master_secret + 24, server_random, 24);
-
-	/* Generate master secret and then key material */
-	sec_hash_48(master_secret, pre_master_secret, client_random, server_random, 'A');
-	sec_hash_48(key_block, master_secret, client_random, server_random, 'X');
-
-	/* First 16 bytes of key material is MAC secret */
-	memcpy(sec->sec_sign_key, key_block, 16);
-
-	/* Generate export keys from next two blocks of 16 bytes */
-	sec_hash_16(sec->sec_decrypt_key, &key_block[16], client_random, server_random);
-	sec_hash_16(sec->sec_encrypt_key, &key_block[32], client_random, server_random);
-
-	if (rc4_key_size == 1)
-	{
-		DEBUG_SEC("40-bit encryption enabled");
-		sec_make_40bit(sec->sec_sign_key);
-		sec_make_40bit(sec->sec_decrypt_key);
-		sec_make_40bit(sec->sec_encrypt_key);
-		sec->rc4_key_len = 8;
-	}
-	else
-	{
-		DEBUG_SEC("rc_4_key_size == %d, 128-bit encryption enabled", rc4_key_size);
-		sec->rc4_key_len = 16;
-	}
-
-	/* Save initial RC4 keys as update keys */
-	memcpy(sec->sec_decrypt_update_key, sec->sec_decrypt_key, 16);
-	memcpy(sec->sec_encrypt_update_key, sec->sec_encrypt_key, 16);
-
-	/* Initialize RC4 state arrays */
-	sec->rc4_decrypt_key = crypto_rc4_init(sec->sec_decrypt_key, sec->rc4_key_len);
-	sec->rc4_encrypt_key = crypto_rc4_init(sec->sec_encrypt_key, sec->rc4_key_len);
-}
-
-/* Output a uint32 into a buffer (little-endian) */
-void
-buf_out_uint32(uint8 * buffer, uint32 value)
-{
-	buffer[0] = (value) & 0xff;
-	buffer[1] = (value >> 8) & 0xff;
-	buffer[2] = (value >> 16) & 0xff;
-	buffer[3] = (value >> 24) & 0xff;
-}
-
-/* Generate a MAC hash (5.2.3.1), using a combination of SHA1 and MD5 */
-void
-sec_sign(uint8 * signature, int siglen, uint8 * session_key, int keylen, uint8 * data, int datalen)
-{
-	uint8 shasig[20];
-	uint8 md5sig[16];
-	uint8 lenhdr[4];
-	CryptoSha1 sha1;
-	CryptoMd5 md5;
-
-	buf_out_uint32(lenhdr, datalen);
-
-	sha1 = crypto_sha1_init();
-	crypto_sha1_update(sha1, session_key, keylen);
-	crypto_sha1_update(sha1, pad_54, 40);
-	crypto_sha1_update(sha1, lenhdr, 4);
-	crypto_sha1_update(sha1, data, datalen);
-	crypto_sha1_final(sha1, shasig);
-
-	md5 = crypto_md5_init();
-	crypto_md5_update(md5, session_key, keylen);
-	crypto_md5_update(md5, pad_92, 48);
-	crypto_md5_update(md5, shasig, 20);
-	crypto_md5_final(md5, md5sig);
-
-	memcpy(signature, md5sig, siglen);
-}
-
-/* Update an encryption key */
-static void
-sec_update(rdpSec * sec, uint8 * key, uint8 * update_key)
-{
-	uint8 shasig[20];
-	CryptoSha1 sha1;
-	CryptoMd5 md5;
-	CryptoRc4 update;
-
-	sha1 = crypto_sha1_init();
-	crypto_sha1_update(sha1, update_key, sec->rc4_key_len);
-	crypto_sha1_update(sha1, pad_54, 40);
-	crypto_sha1_update(sha1, key, sec->rc4_key_len);
-	crypto_sha1_final(sha1, shasig);
-
-	md5 = crypto_md5_init();
-	crypto_md5_update(md5, update_key, sec->rc4_key_len);
-	crypto_md5_update(md5, pad_92, 48);
-	crypto_md5_update(md5, shasig, 20);
-	crypto_md5_final(md5, key);
-
-	update = crypto_rc4_init(key, sec->rc4_key_len);
-	crypto_rc4(update, sec->rc4_key_len, key, key);
-	crypto_rc4_free(update);
-
-	if (sec->rc4_key_len == 8)
-		sec_make_40bit(key);
-}
-
-/* Encrypt data using RC4 */
-static void
-sec_encrypt(rdpSec * sec, uint8 * data, int length)
-{
-	if (sec->sec_encrypt_use_count == 4096)
-	{
-		sec_update(sec, sec->sec_encrypt_key, sec->sec_encrypt_update_key);
-		crypto_rc4_free(sec->rc4_encrypt_key);
-		sec->rc4_encrypt_key = crypto_rc4_init(sec->sec_encrypt_key, sec->rc4_key_len);
-		sec->sec_encrypt_use_count = 0;
-	}
-
-	crypto_rc4(sec->rc4_encrypt_key, length, data, data);
-	sec->sec_encrypt_use_count++;
-}
-
-/* Decrypt data using RC4 */
-static void
-sec_decrypt(rdpSec * sec, uint8 * data, int length)
-{
-#ifndef DISABLE_TLS
-	if (sec->net->tls_connected)
-		return;
-#endif
-
-	if (sec->sec_decrypt_use_count == 4096)
-	{
-		sec_update(sec, sec->sec_decrypt_key, sec->sec_decrypt_update_key);
-		crypto_rc4_free(sec->rc4_decrypt_key);
-		sec->rc4_decrypt_key = crypto_rc4_init(sec->sec_decrypt_key, sec->rc4_key_len);
-		sec->sec_decrypt_use_count = 0;
-	}
-
-	crypto_rc4(sec->rc4_decrypt_key, length, data, data);
-	sec->sec_decrypt_use_count++;
-}
-
-/* Initialize secure transport packet */
-STREAM
-sec_init(rdpSec * sec, uint32 flags, int maxlen)
-{
-	STREAM s;
-	int hdrlen;
-
-	if (flags)
-	{
-		if (!(sec->net->license->license_issued))
-			hdrlen = (flags & SEC_ENCRYPT) ? 12 : 4;
-		else
-			hdrlen = (flags & SEC_ENCRYPT) ? 12 : 0;
-	}
-	else
-		hdrlen = 0;
-
-	s = mcs_init(sec->net->mcs, maxlen + hdrlen);
-	s_push_layer(s, sec_hdr, hdrlen);
-
-	return s;
-}
-
-/* Initialize fast path secure transport packet */
-STREAM
-sec_fp_init(rdpSec * sec, uint32 flags, int maxlen)
-{
-	STREAM s;
-	int hdrlen;
-
-	hdrlen = (flags & SEC_ENCRYPT) ? 8 : 0;
-	s = mcs_fp_init(sec->net->mcs, maxlen + hdrlen);
-	s_push_layer(s, sec_hdr, hdrlen);
-
-	return s;
-}
-
-/* Transmit secure transport packet over specified channel */
-void
-sec_send_to_channel(rdpSec * sec, STREAM s, uint32 flags, uint16 channel)
-{
-	int datalen;
-	s_pop_layer(s, sec_hdr);
-
-	if (flags)
-	{
-		/* Basic Security Header */
-		if (!(sec->net->license->license_issued) || (flags & SEC_ENCRYPT))
-			out_uint32_le(s, flags); /* flags */
-
-		if (flags & SEC_ENCRYPT)
-		{
-			flags &= ~SEC_ENCRYPT;
-			datalen = s->end - s->p - 8;
-
-#if WITH_DEBUG
-			DEBUG_SEC("Sending encrypted packet:");
-			hexdump(s->p + 8, datalen);
-#endif
-
-			sec_sign(s->p, 8, sec->sec_sign_key, sec->rc4_key_len, s->p + 8, datalen);
-			sec_encrypt(sec, s->p + 8, datalen);
-		}
-	}
-
-	mcs_send_to_channel(sec->net->mcs, s, channel);
-}
-
-/* Transmit secure transport packet */
-
-void
-sec_send(rdpSec * sec, STREAM s, uint32 flags)
-{
-	sec_send_to_channel(sec, s, flags, MCS_GLOBAL_CHANNEL);
-}
-
-/* Transmit secure fast path packet */
-void
-sec_fp_send(rdpSec * sec, STREAM s, uint32 flags)
-{
-	int datalen;
-	s_pop_layer(s, sec_hdr);
-	if (flags & SEC_ENCRYPT)
-	{
-		datalen = ((int) (s->end - s->p)) - 8;
-		sec_sign(s->p, 8, sec->sec_sign_key, sec->rc4_key_len, s->p + 8, datalen);
-		sec_encrypt(sec, s->p + 8, datalen);
-	}
-	mcs_fp_send(sec->net->mcs, s, flags);
-}
-
-/* Transfer the client random to the server */
-void
-sec_establish_key(rdpSec * sec)
-{
-	uint32 length = sec->server_public_key_len + SEC_PADDING_SIZE;
-	uint32 flags = SEC_EXCHANGE_PKT;
-	STREAM s;
-
-	s = sec_init(sec, flags, length + 4);
-
-	out_uint32_le(s, length);
-	out_uint8p(s, sec->sec_crypted_random, sec->server_public_key_len);
-	out_uint8s(s, SEC_PADDING_SIZE);
-
-	s_mark_end(s);
-	sec_send(sec, s, flags);
-}
+#include "connect.h"
 
 static void
-sec_out_client_core_data(rdpSec * sec, rdpSet * settings, STREAM s)
+connect_output_client_core_data(rdpSec * sec, rdpSet * settings, STREAM s)
 {
 	char * p;
 	size_t len;
+	int con_type;
 	uint16 highColorDepth;
 	uint16 supportedColorDepths;
 	uint16 earlyCapabilityFlags;
-	int con_type;
 
 	out_uint16_le(s, UDH_CS_CORE);	/* User Data Header type */
 	out_uint16_le(s, 216);		/* total length */
@@ -451,11 +95,11 @@ sec_out_client_core_data(rdpSec * sec, rdpSet * settings, STREAM s)
 		is set in earlyCapabilityFlags */
 	out_uint8(s, con_type);
 	out_uint8(s, 0); /* pad1octet */
-	out_uint32_le(s, sec->net->iso->nego->selected_protocol); /* serverSelectedProtocol */
+	out_uint32_le(s, sec->net->nego->selected_protocol); /* serverSelectedProtocol */
 }
 
 static void
-sec_out_client_security_data(rdpSec * sec, rdpSet * settings, STREAM s)
+connect_output_client_security_data(rdpSec * sec, rdpSet * settings, STREAM s)
 {
 	uint16 encryptionMethods = 0;
 
@@ -470,7 +114,7 @@ sec_out_client_security_data(rdpSec * sec, rdpSet * settings, STREAM s)
 }
 
 static void
-sec_out_client_network_data(rdpSec * sec, rdpSet * settings, STREAM s)
+connect_output_client_network_data(rdpSec * sec, rdpSet * settings, STREAM s)
 {
 	int i;
 
@@ -491,7 +135,7 @@ sec_out_client_network_data(rdpSec * sec, rdpSet * settings, STREAM s)
 }
 
 static void
-sec_out_client_cluster_data(rdpSec * sec, rdpSet * settings, STREAM s)
+connect_output_client_cluster_data(rdpSec * sec, rdpSet * settings, STREAM s)
 {
 	out_uint16_le(s, UDH_CS_CLUSTER);	/* User Data Header type */
 	out_uint16_le(s, 12);			/* total length */
@@ -504,7 +148,7 @@ sec_out_client_cluster_data(rdpSec * sec, rdpSet * settings, STREAM s)
 }
 
 static void
-sec_out_client_monitor_data(rdpSec * sec, rdpSet * settings, STREAM s)
+connect_output_client_monitor_data(rdpSec * sec, rdpSet * settings, STREAM s)
 {
 	int length, n;
 	DEBUG_SEC("Setting monitor data... num_monitors: %d", settings->num_monitors);
@@ -522,7 +166,7 @@ sec_out_client_monitor_data(rdpSec * sec, rdpSet * settings, STREAM s)
 	{
 		out_uint32_le(s, settings->monitors[n].x); /* left */
 		out_uint32_le(s, settings->monitors[n].y); /* top */
-		out_uint32_le(s, settings->monitors[n].x + 
+		out_uint32_le(s, settings->monitors[n].x +
 						 settings->monitors[n].width-1); /* right */
 		out_uint32_le(s, settings->monitors[n].y +
 						 settings->monitors[n].height-1); /* bottom */
@@ -531,7 +175,7 @@ sec_out_client_monitor_data(rdpSec * sec, rdpSet * settings, STREAM s)
 }
 
 void
-sec_out_gcc_conference_create_request(rdpSec * sec, STREAM s)
+connect_output_gcc_conference_create_request(rdpSec * sec, STREAM s)
 {
 	int length;
 	rdpSet * settings = sec->rdp->settings;
@@ -540,11 +184,11 @@ sec_out_gcc_conference_create_request(rdpSec * sec, STREAM s)
 
 	/* the part before userData is of a fixed size, making things convenient */
 	s->p = s->data + 23;
-	sec_out_client_core_data(sec, settings, s);
-	sec_out_client_cluster_data(sec, settings, s);
-	sec_out_client_security_data(sec, settings, s);
-	sec_out_client_network_data(sec, settings, s);
-	sec_out_client_monitor_data(sec, settings, s);
+	connect_output_client_core_data(sec, settings, s);
+	connect_output_client_cluster_data(sec, settings, s);
+	connect_output_client_security_data(sec, settings, s);
+	connect_output_client_network_data(sec, settings, s);
+	connect_output_client_monitor_data(sec, settings, s);
 	length = (s->p - s->data) - 23;
 	s->p = s->data;
 
@@ -570,70 +214,9 @@ sec_out_gcc_conference_create_request(rdpSec * sec, STREAM s)
 	s_mark_end(s);
 }
 
-static void
-revcpy(uint8 * out, uint8 * in, int len)
-{
-	int i;
-	in += len;
-	for (i = 0; i < len; i++)
-	{
-		*out++ = *--in;
-	}
-}
-
-/* Parse a Server Proprietary Certificate RSA Public Key */
-static RD_BOOL
-sec_parse_public_key(rdpSec * sec, STREAM s, uint32 len, uint8 * modulus, uint8 * exponent)
-{
-	uint32 magic;
-	uint32 modulus_len;
-
-	in_uint32_le(s, magic);
-	if (magic != SEC_RSA_MAGIC)
-	{
-		ui_error(sec->rdp->inst, "RSA magic 0x%x\n", magic);
-		return False;
-	}
-
-	in_uint32_le(s, modulus_len);
-	if (4 + 4 + 4 + 4 + SEC_EXPONENT_SIZE + modulus_len != len)
-	{
-		ui_error(sec->rdp->inst, "Inconsistent Server Proprietary Certificate public key size\n");
-		return False;
-	}
-	modulus_len -= SEC_PADDING_SIZE;
-	if ((modulus_len < SEC_MODULUS_SIZE) || (modulus_len > SEC_MAX_MODULUS_SIZE))
-	{
-		ui_error(sec->rdp->inst, "Bad Server Proprietary Certificate public key size (%u bits)\n", modulus_len * 8);
-		return False;
-	}
-
-	in_uint8s(s, 4);	/* modulus_bits - must match modulus_len */
-	in_uint8s(s, 4);	/* datalen - how much data can be encoded */
-	revcpy(exponent, s->p, SEC_EXPONENT_SIZE);
-	in_uint8s(s, SEC_EXPONENT_SIZE);
-	revcpy(modulus, s->p, modulus_len);
-	in_uint8s(s, modulus_len);
-	in_uint8s(s, SEC_PADDING_SIZE);	/* zero padding - included in modulus_len but not in modulus_bits */
-	sec->server_public_key_len = modulus_len;
-
-	return s_check(s);
-}
-
-/* Parse a Proprietary Certificate signature */
-static RD_BOOL
-sec_parse_public_sig(STREAM s, uint32 len)
-{
-	/* The Proprietary Certificate signature uses a static published private key.
-	 * That is completely nonsense, so we won't bother checking it. */
-
-	in_uint8s(s, len);
-	return len == 72;
-}
-
 /* Parse Server Security Data */
 static RD_BOOL
-sec_parse_server_security_data(rdpSec * sec, STREAM s, uint32 * encryptionMethod, uint8 server_random[SEC_RANDOM_SIZE], uint8 * modulus, uint8 * exponent)
+connect_process_server_security_data(rdpSec * sec, STREAM s, uint32 * encryptionMethod, uint8 server_random[SEC_RANDOM_SIZE], uint8 * modulus, uint8 * exponent)
 {
 	uint32 encryptionLevel;
 	uint32 serverRandomLen;
@@ -789,7 +372,7 @@ sec_parse_server_security_data(rdpSec * sec, STREAM s, uint32 * encryptionMethod
 
 /* Process Server Security Data */
 static void
-sec_process_server_security_data(rdpSec * sec, STREAM s)
+connect_input_server_security_data(rdpSec * sec, STREAM s)
 {
 	uint32 rc4_key_size;
 	uint8 server_random[SEC_RANDOM_SIZE];
@@ -801,7 +384,7 @@ sec_process_server_security_data(rdpSec * sec, STREAM s)
 
 	memset(modulus, 0, sizeof(modulus));
 	memset(exponent, 0, sizeof(exponent));
-	if (!sec_parse_server_security_data(sec, s, &rc4_key_size, server_random, modulus, exponent))
+	if (!connect_process_server_security_data(sec, s, &rc4_key_size, server_random, modulus, exponent))
 	{
 		/* encryptionMethod (rc4_key_size) = 0 means TLS */
 		if (rc4_key_size > 0)
@@ -813,16 +396,16 @@ sec_process_server_security_data(rdpSec * sec, STREAM s)
 
 	DEBUG_SEC("Generating client random");
 	generate_random(client_random);
-	revcpy(client_random_rev, client_random, SEC_RANDOM_SIZE);
+	sec_reverse_copy(client_random_rev, client_random, SEC_RANDOM_SIZE);
 	crypto_rsa_encrypt(SEC_RANDOM_SIZE, client_random_rev, crypted_random_rev,
 			sec->server_public_key_len, modulus, exponent);
-	revcpy(sec->sec_crypted_random, crypted_random_rev, sec->server_public_key_len);
+	sec_reverse_copy(sec->sec_crypted_random, crypted_random_rev, sec->server_public_key_len);
 	sec_generate_keys(sec, client_random, server_random, rc4_key_size);
 }
 
 /* Process Server Core Data */
 static void
-sec_process_server_core_data(rdpSec * sec, STREAM s, uint16 length)
+connect_input_server_core_data(rdpSec * sec, STREAM s, uint16 length)
 {
 	uint32 server_rdp_version, clientRequestedProtocols;
 	in_uint32_le(s, server_rdp_version);
@@ -850,7 +433,7 @@ sec_process_server_core_data(rdpSec * sec, STREAM s, uint16 length)
 
 /* Process Server Network Data */
 static void
-sec_process_server_network_data(rdpSec * sec, STREAM s)
+connect_input_server_network_data(rdpSec * sec, STREAM s)
 {
 	int i;
 	uint16 MCSChannelId;
@@ -889,7 +472,7 @@ sec_process_server_network_data(rdpSec * sec, STREAM s)
 
 /* Process connect response data blob */
 void
-sec_process_mcs_data(rdpSec * sec, STREAM s)
+connect_process_mcs_data(rdpSec * sec, STREAM s)
 {
 	uint8 byte;
 	uint16 type;
@@ -923,15 +506,15 @@ sec_process_mcs_data(rdpSec * sec, STREAM s)
 		switch (type)
 		{
 			case UDH_SC_CORE: /* Server Core Data */
-				sec_process_server_core_data(sec, s, length);
+				connect_input_server_core_data(sec, s, length);
 				break;
 
 			case UDH_SC_NET: /* Server Network Data */
-				sec_process_server_network_data(sec, s);
+				connect_input_server_network_data(sec, s);
 				break;
 
 			case UDH_SC_SECURITY: /* Server Security Data */
-				sec_process_server_security_data(sec, s);
+				connect_input_server_security_data(sec, s);
 				break;
 		}
 
@@ -939,111 +522,4 @@ sec_process_mcs_data(rdpSec * sec, STREAM s)
 	}
 }
 
-/* Receive secure transport packet
- * Some package types are processed internally.
- * If s is returned a package of *type must be processed by the caller */
-STREAM
-sec_recv(rdpSec * sec, secRecvType * type)
-{
-	STREAM s;
-	uint16 channel;
-	uint32 sec_flags;
-	isoRecvType iso_type;
 
-	while ((s = mcs_recv(sec->net->mcs, &iso_type, &channel)) != NULL)
-	{
-		if ((iso_type == ISO_RECV_FAST_PATH) ||
-			(iso_type == ISO_RECV_FAST_PATH_ENCRYPTED))
-		{
-			*type = SEC_RECV_FAST_PATH;
-			if (iso_type == ISO_RECV_FAST_PATH_ENCRYPTED)
-			{
-				in_uint8s(s, 8);	/* dataSignature */ /* TODO: Check signature! */
-				sec_decrypt(sec, s->p, s->end - s->p);
-			}
-			return s;
-		}
-		if (iso_type != ISO_RECV_X224)
-		{
-			ui_error(sec->rdp->inst, "expected ISO_RECV_X224, got %d\n", iso_type);
-			return NULL;
-		}
-		if (sec->rdp->settings->encryption || !sec->net->license->license_issued)
-		{
-			/* basicSecurityHeader: */
-			in_uint32_le(s, sec_flags);
-
-			if ((sec_flags & SEC_ENCRYPT) || (sec_flags & SEC_REDIRECTION_PKT))
-			{
-				in_uint8s(s, 8);	/* dataSignature */ /* TODO: Check signature! */
-				sec_decrypt(sec, s->p, s->end - s->p);
-			}
-
-			if (sec_flags & SEC_LICENSE_PKT)
-			{
-				*type = SEC_RECV_LICENSE;
-				license_process(sec->net->license, s);
-				continue;
-			}
-
-			if (sec_flags & SEC_REDIRECTION_PKT)
-			{
-				*type = SEC_RECV_REDIRECT;
-				return s;
-			}
-		}
-
-		if (channel != MCS_GLOBAL_CHANNEL)
-		{
-			vchan_process(sec->net->mcs->chan, s, channel);
-			*type = SEC_RECV_IOCHANNEL;
-			return s;
-		}
-		*type = SEC_RECV_SHARE_CONTROL;
-		return s;
-	}
-
-	return NULL;
-}
-
-/* Disconnect a connection */
-void
-sec_disconnect(rdpSec * sec)
-{
-	mcs_disconnect(sec->net->mcs);
-
-	if (sec->rc4_decrypt_key)
-		crypto_rc4_free(sec->rc4_decrypt_key);
-	sec->rc4_decrypt_key = NULL;
-	if (sec->rc4_encrypt_key)
-		crypto_rc4_free(sec->rc4_encrypt_key);
-	sec->rc4_encrypt_key = NULL;
-}
-
-rdpSec *
-sec_new(struct rdp_rdp * rdp)
-{
-	rdpSec * self;
-
-	self = (rdpSec *) xmalloc(sizeof(rdpSec));
-	if (self != NULL)
-	{
-		memset(self, 0, sizeof(rdpSec));
-		self->rdp = rdp;
-		self->rc4_decrypt_key = NULL;
-		self->rc4_encrypt_key = NULL;
-		self->net = rdp->net;
-	}
-	return self;
-}
-
-void
-sec_free(rdpSec * sec)
-{
-	if (sec != NULL)
-	{
-		license_free(sec->net->license);
-		mcs_free(sec->net->mcs);
-		xfree(sec);
-	}
-}

--- a/libfreerdp-core/connect.h
+++ b/libfreerdp-core/connect.h
@@ -1,0 +1,26 @@
+/*
+   FreeRDP: A Remote Desktop Protocol client.
+   Connection Sequence
+
+   Copyright 2011 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef __CONNECT_H
+#define __CONNECT_H
+
+void
+connect_output_gcc_conference_create_request(rdpSec * sec, STREAM s);
+
+#endif /* __CONNECT_H */

--- a/libfreerdp-core/credssp.c
+++ b/libfreerdp-core/credssp.c
@@ -21,7 +21,7 @@
 #include "rdp.h"
 #include "tls.h"
 #include "asn1.h"
-#include "secure.h"
+#include "security.h"
 #include "stream.h"
 #include "tcp.h"
 #include "mcs.h"

--- a/libfreerdp-core/credssp.c
+++ b/libfreerdp-core/credssp.c
@@ -58,7 +58,7 @@ asn1_write(const void *buffer, size_t size, void *fd)
 void credssp_ntlmssp_init(rdpCredssp *credssp)
 {
 	NTLMSSP *ntlmssp = credssp->ntlmssp;
-	rdpSet *settings = credssp->sec->rdp->settings;
+	rdpSet *settings = credssp->net->rdp->settings;
 
 	ntlmssp_set_password(ntlmssp, settings->password);
 	ntlmssp_set_username(ntlmssp, settings->username);
@@ -92,7 +92,7 @@ int credssp_get_public_key(rdpCredssp *credssp)
 	CryptoCert cert;
 	int ret;
 
-	cert = tls_get_certificate(credssp->sec->tls);
+	cert = tls_get_certificate(credssp->net->tls);
 	if (cert == NULL)
 	{
 		printf("credssp_get_public_key: tls_get_certificate failed to return the server certificate.\n");
@@ -396,7 +396,7 @@ void credssp_send(rdpCredssp *credssp, DATABLOB *negoToken, DATABLOB *pubKeyAuth
 
 		if (enc_rval.encoded != -1)
 		{
-			tls_write(credssp->sec->tls, buffer, size);
+			tls_write(credssp->net->tls, buffer, size);
 		}
 
 		asn_DEF_TSRequest.free_struct(&asn_DEF_TSRequest, ts_request, 0);
@@ -422,7 +422,7 @@ int credssp_recv(rdpCredssp *credssp, DATABLOB *negoToken, DATABLOB *pubKeyAuth,
 	TSRequest_t *ts_request = 0;
 
 	recv_buffer = xmalloc(size);
-	bytes_read = tls_read(credssp->sec->tls, recv_buffer, size);
+	bytes_read = tls_read(credssp->net->tls, recv_buffer, size);
 
 	if (bytes_read < 0)
 		return -1;
@@ -503,7 +503,7 @@ void credssp_current_time(uint8* timestamp)
  */
 
 rdpCredssp *
-credssp_new(struct rdp_sec * sec)
+credssp_new(struct rdp_network * net)
 {
 	rdpCredssp * self;
 
@@ -511,7 +511,7 @@ credssp_new(struct rdp_sec * sec)
 	if (self != NULL)
 	{
 		memset(self, 0, sizeof(rdpCredssp));
-		self->sec = sec;
+		self->net = net;
 		self->send_seq_num = 0;
 		self->ntlmssp = ntlmssp_new();
 	}

--- a/libfreerdp-core/credssp.h
+++ b/libfreerdp-core/credssp.h
@@ -20,7 +20,7 @@
 #ifndef __CREDSSP_H
 #define __CREDSSP_H
 
-#include "secure.h"
+#include "network.h"
 #include "ntlmssp.h"
 
 struct rdp_credssp
@@ -33,7 +33,7 @@ struct rdp_credssp
 	DATABLOB ts_credentials;
 	CryptoRc4 rc4_seal_state;
 	struct _NTLMSSP *ntlmssp;
-	struct rdp_sec * sec;
+	struct rdp_network * net;
 };
 typedef struct rdp_credssp rdpCredssp;
 
@@ -50,7 +50,7 @@ void credssp_encode_ts_credentials(rdpCredssp *credssp);
 void credssp_current_time(uint8* timestamp);
 void credssp_rc4k(uint8* key, int length, uint8* plaintext, uint8* ciphertext);
 
-rdpCredssp* credssp_new(rdpSec *sec);
+rdpCredssp* credssp_new(struct rdp_network * net);
 void credssp_free(rdpCredssp *credssp);
 
-#endif // __CREDSSP_H
+#endif /* __CREDSSP_H */

--- a/libfreerdp-core/crypto/openssl.c
+++ b/libfreerdp-core/crypto/openssl.c
@@ -19,6 +19,7 @@
 
 #include "frdp.h"
 #include "crypto.h"
+#include <freerdp/types/base.h>
 #include <freerdp/utils/memory.h>
 #include <freerdp/constants/constants.h>
 #include <time.h>

--- a/libfreerdp-core/frdp.h
+++ b/libfreerdp-core/frdp.h
@@ -53,8 +53,6 @@ void
 ui_warning(rdpInst * inst, char * format, ...);
 void
 ui_unimpl(rdpInst * inst, char * format, ...);
-void
-hexdump(unsigned char * p, int len);
 int
 load_license(unsigned char ** data);
 RD_BOOL

--- a/libfreerdp-core/freerdp.c
+++ b/libfreerdp-core/freerdp.c
@@ -19,7 +19,7 @@
 #include <stdarg.h>
 #include "frdp.h"
 #include "rdp.h"
-#include "secure.h"
+#include "security.h"
 #include "mcs.h"
 #include "iso.h"
 #include "tcp.h"

--- a/libfreerdp-core/freerdp.c
+++ b/libfreerdp-core/freerdp.c
@@ -452,7 +452,7 @@ l_rdp_get_fds(rdpInst * inst, void ** read_fds, int * read_count,
 #ifdef _WIN32
 	read_fds[*read_count] = (void *) (rdp->net->tcp->wsa_event);
 #else
-	read_fds[*read_count] = (void *)(long) (rdp->net->tcp->sock);
+	read_fds[*read_count] = (void *)(long) (rdp->net->tcp->sockfd);
 #endif
 	(*read_count)++;
 	return 0;
@@ -471,7 +471,7 @@ l_rdp_check_fds(rdpInst * inst)
 	WSAResetEvent(rdp->net->tcp->wsa_event);
 #endif
 	rv = 0;
-	if (tcp_can_recv(rdp->net->tcp->sock, 0))
+	if (tcp_can_recv(rdp->net->tcp->sockfd, 0))
 	{
 		if (!rdp_loop(rdp, &deactivated))
 		{

--- a/libfreerdp-core/freerdp.c
+++ b/libfreerdp-core/freerdp.c
@@ -27,6 +27,7 @@
 #include "ext.h"
 #include <freerdp/freerdp.h>
 #include <freerdp/utils/memory.h>
+#include <freerdp/utils/hexdump.h>
 
 #define RDP_FROM_INST(_inst) ((rdpRdp *) (_inst->rdp))
 
@@ -88,34 +89,6 @@ ui_unimpl(rdpInst * inst, char * format, ...)
 	inst->ui_unimpl(inst, text2);
 	xfree(text1);
 	xfree(text2);
-}
-
-void
-hexdump(unsigned char * p, int len)
-{
-	unsigned char *line = p;
-	int i, thisline, offset = 0;
-
-	while (offset < len)
-	{
-		printf("%04x ", offset);
-		thisline = len - offset;
-		if (thisline > 16)
-			thisline = 16;
-
-		for (i = 0; i < thisline; i++)
-			printf("%02x ", line[i]);
-
-		for (; i < 16; i++)
-			printf("   ");
-
-		for (i = 0; i < thisline; i++)
-			printf("%c", (line[i] >= 0x20 && line[i] < 0x7f) ? line[i] : '.');
-
-		printf("\n");
-		offset += thisline;
-		line += thisline;
-	}
 }
 
 int

--- a/libfreerdp-core/freerdp.c
+++ b/libfreerdp-core/freerdp.c
@@ -450,9 +450,9 @@ l_rdp_get_fds(rdpInst * inst, void ** read_fds, int * read_count,
 
 	rdp = RDP_FROM_INST(inst);
 #ifdef _WIN32
-	read_fds[*read_count] = (void *) (rdp->sec->mcs->iso->tcp->wsa_event);
+	read_fds[*read_count] = (void *) (rdp->net->tcp->wsa_event);
 #else
-	read_fds[*read_count] = (void *)(long) (rdp->sec->mcs->iso->tcp->sock);
+	read_fds[*read_count] = (void *)(long) (rdp->net->tcp->sock);
 #endif
 	(*read_count)++;
 	return 0;
@@ -468,10 +468,10 @@ l_rdp_check_fds(rdpInst * inst)
 
 	rdp = RDP_FROM_INST(inst);
 #ifdef _WIN32
-	WSAResetEvent(rdp->sec->mcs->iso->tcp->wsa_event);
+	WSAResetEvent(rdp->net->tcp->wsa_event);
 #endif
 	rv = 0;
-	if (tcp_can_recv(rdp->sec->mcs->iso->tcp->sock, 0))
+	if (tcp_can_recv(rdp->net->tcp->sock, 0))
 	{
 		if (!rdp_loop(rdp, &deactivated))
 		{
@@ -532,7 +532,7 @@ l_rdp_channel_data(rdpInst * inst, int chan_id, char * data, int data_size)
 	rdpChannels * chan;
 
 	rdp = RDP_FROM_INST(inst);
-	chan = rdp->sec->mcs->chan;
+	chan = rdp->net->mcs->chan;
 	return vchan_send(chan, chan_id, data, data_size);
 }
 

--- a/libfreerdp-core/iso.c
+++ b/libfreerdp-core/iso.c
@@ -20,7 +20,7 @@
 #include "tcp.h"
 #include "mcs.h"
 #include "nego.h"
-#include "secure.h"
+#include "security.h"
 #include "credssp.h"
 #include "rdp.h"
 #include <freerdp/rdpset.h>

--- a/libfreerdp-core/iso.c
+++ b/libfreerdp-core/iso.c
@@ -80,7 +80,7 @@ x224_send_dst_src_class(rdpIso * iso, uint8 code)
 	out_uint8(s, 0);	/* class */
 
 	s_mark_end(s);
-	tcp_send(iso->tcp, s);
+	network_send(iso->net, s);
 }
 
 /* Output and send X.224 Connection Request TPDU with routing for username */
@@ -93,9 +93,9 @@ x224_send_connection_request(rdpIso * iso)
 
 	cookie_length = strlen(iso->cookie);
 
-	if (iso->mcs->sec->rdp->redirect_routingtoken)
+	if (iso->net->rdp->redirect_routingtoken)
 		/* routingToken */
-		length += iso->mcs->sec->rdp->redirect_routingtoken_len;
+		length += iso->net->rdp->redirect_routingtoken_len;
 	else
 		/* cookie */
 		length += 19 + cookie_length;
@@ -115,10 +115,10 @@ x224_send_connection_request(rdpIso * iso)
 	out_uint16_le(s, 0);	/* src_ref */
 	out_uint8(s, 0);	/* class */
 
-	if (iso->mcs->sec->rdp->redirect_routingtoken)
+	if (iso->net->rdp->redirect_routingtoken)
 	{
 		/* routingToken */
-		out_uint8p(s, iso->mcs->sec->rdp->redirect_routingtoken, iso->mcs->sec->rdp->redirect_routingtoken_len);
+		out_uint8p(s, iso->net->rdp->redirect_routingtoken, iso->net->rdp->redirect_routingtoken_len);
 	}
 	else
 	{
@@ -138,7 +138,7 @@ x224_send_connection_request(rdpIso * iso)
 	}
 
 	s_mark_end(s);
-	tcp_send(iso->tcp, s);
+	network_send(iso->net, s);
 }
 
 /* Receive an X.224 TPDU */
@@ -149,7 +149,7 @@ x224_recv(rdpIso * iso, STREAM s, int length, uint8 * pcode)
 	uint8 code;
 	uint8 subcode;
 
-	s = tcp_recv(iso->tcp, s, length - 4);
+	s = network_recv(iso->net, s, length - 4);
 
 	if (s == NULL)
 		return NULL;
@@ -217,7 +217,7 @@ tpkt_recv(rdpIso * iso, uint8 * pcode, isoRecvType * ptype)
 	STREAM s;
 	int length;
 
-	s = tcp_recv(iso->tcp, NULL, 4);
+	s = network_recv(iso->net, NULL, 4);
 
 	if (s == NULL)
 		return NULL;
@@ -250,7 +250,7 @@ tpkt_recv(rdpIso * iso, uint8 * pcode, isoRecvType * ptype)
 			next_be(s, length);
 		}
 
-		s = tcp_recv(iso->tcp, s, length - 4);
+		s = network_recv(iso->net, s, length - 4);
 		return s;
 	}
 	return NULL;	/* Fast-Path not allowed */
@@ -300,7 +300,7 @@ iso_send(rdpIso * iso, STREAM s)
 	out_uint8(s, X224_TPDU_DATA);	/* code */
 	out_uint8(s, 0x80);		/* eot */
 
-	tcp_send(iso->tcp, s);
+	network_send(iso->net, s);
 }
 
 /* Send an fast path data PDU */
@@ -335,7 +335,7 @@ iso_fp_send(rdpIso * iso, STREAM s, uint32 flags)
 		out_uint8(s, len);
 	}
 
-	tcp_send(iso->tcp, s);
+	network_send(iso->net, s);
 }
 
 /* Receive ISO transport data packet
@@ -355,7 +355,7 @@ iso_recv(rdpIso * iso, isoRecvType * ptype)
 		(*ptype == ISO_RECV_X224) &&
 		(code != X224_TPDU_DATA))
 	{
-		ui_error(iso->mcs->sec->rdp->inst, "expected X224_TPDU_DATA, got 0x%x\n", code);
+		ui_error(iso->net->rdp->inst, "expected X224_TPDU_DATA, got 0x%x\n", code);
 		return NULL;
 	}
 
@@ -366,8 +366,14 @@ iso_recv(rdpIso * iso, isoRecvType * ptype)
 RD_BOOL
 iso_connect(rdpIso * iso, char *server, char *username, int port)
 {
-	if (strlen(iso->mcs->sec->rdp->settings->domain) > 0)
-		iso->cookie = iso->mcs->sec->rdp->settings->domain;
+	if (iso->net == NULL)
+		printf("iso->net\n");
+
+	if (iso->net->rdp == NULL)
+		printf("iso->net->rdp\n");
+
+	if (strlen(iso->net->rdp->settings->domain) > 0)
+		iso->cookie = iso->net->rdp->settings->domain;
 	else
 		iso->cookie = username;
 
@@ -376,6 +382,7 @@ iso_connect(rdpIso * iso, char *server, char *username, int port)
 	iso->nego->tcp_connected = 0;
 
 	nego_init(iso->nego);
+
 	if (nego_connect(iso->nego) > 0)
 	{
 		return True;
@@ -393,14 +400,14 @@ iso_disconnect(rdpIso * iso)
 {
 	x224_send_dst_src_class(iso, X224_TPDU_DISCONNECT_REQUEST);
 #ifndef DISABLE_TLS
-	if (iso->mcs->sec->tls)
-		tls_disconnect(iso->mcs->sec->tls);
+	if (iso->net->tls)
+		tls_disconnect(iso->net->tls);
 #endif
 	tcp_disconnect(iso->tcp);
 }
 
 rdpIso *
-iso_new(struct rdp_mcs *mcs)
+iso_new(struct rdp_network * net)
 {
 	rdpIso *self;
 
@@ -409,7 +416,8 @@ iso_new(struct rdp_mcs *mcs)
 	if (self != NULL)
 	{
 		memset(self, 0, sizeof(rdpIso));
-		self->mcs = mcs;
+		self->net = net;
+		self->mcs = net->mcs;
 		self->tcp = tcp_new(self);
 		self->nego = nego_new(self);
 	}

--- a/libfreerdp-core/iso.h
+++ b/libfreerdp-core/iso.h
@@ -18,6 +18,8 @@
 */
 
 #include <freerdp/types/ui.h>
+
+#include "network.h"
 #include "stream.h"
 #include "nego.h"
 
@@ -28,8 +30,9 @@ struct rdp_iso
 {
 	char* cookie;
 	struct _NEGO * nego;
-	struct rdp_mcs * mcs;
 	struct rdp_tcp * tcp;
+	struct rdp_mcs * mcs;
+	struct rdp_network * net;
 };
 typedef struct rdp_iso rdpIso;
 
@@ -60,7 +63,7 @@ iso_connect(rdpIso * iso, char * server, char * username, int port);
 void
 iso_disconnect(rdpIso * iso);
 rdpIso *
-iso_new(struct rdp_mcs * mcs);
+iso_new(struct rdp_network * net);
 void
 iso_free(rdpIso * iso);
 

--- a/libfreerdp-core/iso.h
+++ b/libfreerdp-core/iso.h
@@ -30,7 +30,6 @@ struct rdp_iso
 {
 	char* cookie;
 	struct _NEGO * nego;
-	struct rdp_tcp * tcp;
 	struct rdp_mcs * mcs;
 	struct rdp_network * net;
 };

--- a/libfreerdp-core/license.c
+++ b/libfreerdp-core/license.c
@@ -397,6 +397,7 @@ license_process(rdpLicense * license, STREAM s)
 
 		default:
 			ui_unimpl(license->net->rdp->inst, "Unknown license tag 0x%x", tag);
+			break;
 	}
 	s->p = license_start + wMsgSize;	/* FIXME: Shouldn't be necessary if parsed properly */
 	ASSERT(s->p <= s->end);

--- a/libfreerdp-core/license.c
+++ b/libfreerdp-core/license.c
@@ -19,7 +19,7 @@
 
 #include "frdp.h"
 #include "crypto.h"
-#include "secure.h"
+#include "security.h"
 #include "rdp.h"
 #include <freerdp/rdpset.h>
 #include <freerdp/utils/memory.h>

--- a/libfreerdp-core/license.h
+++ b/libfreerdp-core/license.h
@@ -21,12 +21,13 @@
 #define __LICENSE_H
 
 #include "stream.h"
+#include "network.h"
 #include <freerdp/types/ui.h>
 #include <freerdp/utils/debug.h>
 
 struct rdp_license
 {
-	struct rdp_sec * sec;
+	struct rdp_network * net;
 	uint8 license_key[16];
 	uint8 license_sign_key[16];
 	RD_BOOL license_issued;
@@ -36,7 +37,7 @@ typedef struct rdp_license rdpLicense;
 void
 license_process(rdpLicense * license, STREAM s);
 rdpLicense *
-license_new(struct rdp_sec * secure);
+license_new(struct rdp_network * net);
 void
 license_free(rdpLicense * license);
 

--- a/libfreerdp-core/mcs.c
+++ b/libfreerdp-core/mcs.c
@@ -20,10 +20,11 @@
 #include "frdp.h"
 #include "iso.h"
 #include "chan.h"
-#include "secure.h"
 #include "rdp.h"
 #include "asn1.h"
 #include "tcp.h"
+#include "connect.h"
+#include "security.h"
 #include <freerdp/rdpset.h>
 #include <freerdp/utils/memory.h>
 
@@ -69,7 +70,7 @@ mcs_send_connect_initial(rdpMcs * mcs)
 	gccCCrq.p = gccCCrq.data = (uint8 *) xmalloc(gccCCrq.size);
 	gccCCrq.end = gccCCrq.data + gccCCrq.size;
 
-	sec_out_gcc_conference_create_request(mcs->net->sec, &gccCCrq);
+	connect_output_gcc_conference_create_request(mcs->net->sec, &gccCCrq);
 	gccCCrq_length = gccCCrq.end - gccCCrq.data;
 	length = 9 + 3 * 34 + 4 + gccCCrq_length;
 
@@ -125,7 +126,7 @@ mcs_recv_connect_response(rdpMcs * mcs)
 
 	ber_parse_header(mcs, s, BER_TAG_OCTET_STRING, &length);
 
-	sec_process_mcs_data(mcs->net->sec, s);
+	connect_process_mcs_data(mcs->net->sec, s);
 	return s_check_end(s);
 }
 

--- a/libfreerdp-core/mcs.h
+++ b/libfreerdp-core/mcs.h
@@ -21,13 +21,14 @@
 #define __MCS_H
 
 #include "iso.h"
+#include "network.h"
 #include <freerdp/utils/debug.h>
 
 struct rdp_mcs
 {
-	struct rdp_sec * sec;
 	uint16 mcs_userid;
 	struct rdp_iso * iso;
+	struct rdp_network * net;
 	struct rdp_channels * chan;
 };
 typedef struct rdp_mcs rdpMcs;
@@ -49,7 +50,7 @@ mcs_connect(rdpMcs * mcs);
 void
 mcs_disconnect(rdpMcs * mcs);
 rdpMcs *
-mcs_new(struct rdp_sec * secure);
+mcs_new(struct rdp_network * net);
 void
 mcs_free(rdpMcs * mcs);
 

--- a/libfreerdp-core/nego.c
+++ b/libfreerdp-core/nego.c
@@ -69,7 +69,7 @@ int nego_tcp_connect(NEGO *nego)
 {
 	if (nego->tcp_connected == 0)
 	{
-		if (tcp_connect(nego->iso->tcp, nego->hostname, nego->port) == False)
+		if (tcp_connect(nego->net->tcp, nego->hostname, nego->port) == False)
 		{
 			nego->tcp_connected = 0;
 			return 0;
@@ -93,7 +93,7 @@ int nego_tcp_connect(NEGO *nego)
 int nego_tcp_disconnect(NEGO *nego)
 {
 	if (nego->tcp_connected)
-		tcp_disconnect(nego->iso->tcp);
+		tcp_disconnect(nego->net->tcp);
 
 	nego->tcp_connected = 0;
 	return 1;
@@ -110,8 +110,8 @@ void nego_attempt_nla(NEGO *nego)
 	nego->requested_protocols = PROTOCOL_NLA | PROTOCOL_TLS;
 
 	nego_tcp_connect(nego);
-	x224_send_connection_request(nego->iso);
-	tpkt_recv(nego->iso, &code, NULL);
+	x224_send_connection_request(nego->net->iso);
+	tpkt_recv(nego->net->iso, &code, NULL);
 
 	if (nego->state != NEGO_STATE_FINAL)
 	{
@@ -137,8 +137,8 @@ void nego_attempt_tls(NEGO *nego)
 	nego->requested_protocols = PROTOCOL_TLS;
 
 	nego_tcp_connect(nego);
-	x224_send_connection_request(nego->iso);
-	tpkt_recv(nego->iso, &code, NULL);
+	x224_send_connection_request(nego->net->iso);
+	tpkt_recv(nego->net->iso, &code, NULL);
 
 	if (nego->state != NEGO_STATE_FINAL)
 	{
@@ -162,9 +162,9 @@ void nego_attempt_rdp(NEGO *nego)
 	nego->requested_protocols = PROTOCOL_RDP;
 
 	nego_tcp_connect(nego);
-	x224_send_connection_request(nego->iso);
+	x224_send_connection_request(nego->net->iso);
 
-	if (tpkt_recv(nego->iso, &code, NULL) == NULL)
+	if (tpkt_recv(nego->net->iso, &code, NULL) == NULL)
 		nego->state = NEGO_STATE_FAIL;
 	else
 		nego->state = NEGO_STATE_FINAL;
@@ -278,14 +278,14 @@ void nego_process_negotiation_failure(NEGO *nego, STREAM s)
  * @return
  */
 
-NEGO* nego_new(struct rdp_iso * iso)
+NEGO* nego_new(struct rdp_network * net)
 {
 	NEGO *nego = (NEGO*) xmalloc(sizeof(NEGO));
 
 	if (nego != NULL)
 	{
 		memset(nego, '\0', sizeof(NEGO));
-		nego->iso = iso;
+		nego->net = net;
 		nego_init(nego);
 	}
 

--- a/libfreerdp-core/nego.h
+++ b/libfreerdp-core/nego.h
@@ -22,7 +22,7 @@
 
 #include "frdp.h"
 #include "stream.h"
-#include "iso.h"
+#include "network.h"
 
 enum _NEGO_STATE
 {
@@ -41,7 +41,7 @@ struct _NEGO
 	char *hostname;
 	NEGO_STATE state;
 	int tcp_connected;
-	struct rdp_iso * iso;
+	struct rdp_network * net;
 	uint32 selected_protocol;
 	uint32 requested_protocols;
 	uint8 enabled_protocols[3];
@@ -60,7 +60,7 @@ void nego_recv(NEGO *nego, STREAM s);
 void nego_process_negotiation_response(NEGO *nego, STREAM s);
 void nego_process_negotiation_failure(NEGO *nego, STREAM s);
 
-NEGO* nego_new(rdpIso * iso);
+NEGO* nego_new(struct rdp_network * net);
 void nego_init(NEGO *nego);
 void nego_free(NEGO *nego);
 

--- a/libfreerdp-core/network.c
+++ b/libfreerdp-core/network.c
@@ -1,0 +1,286 @@
+/*
+   FreeRDP: A Remote Desktop Protocol client.
+   Network Transport Abstraction Layer
+
+   Copyright 2011 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <freerdp/utils/memory.h>
+
+#include "network.h"
+
+#ifndef DISABLE_TLS
+
+/* verify SSL/TLS connection integrity. 2 checks are carried out. First make sure that the
+ * certificate is assigned to the server we're connected to, and second make sure that the
+ * certificate is signed by a trusted certification authority
+ */
+
+RD_BOOL
+network_verify_tls(rdpNetwork * net)
+{
+	char * issuer;
+	char * subject;
+	char * fingerprint;
+	CryptoCert cert;
+	RD_BOOL verified = False;
+
+#ifdef _WIN32
+	/*
+	 * TODO: FIX ME! This is really bad, I know...
+	 * There appears to be a buffer overflow only
+	 * on Windows that affects this part of the code.
+	 * Skipping it is a workaround, but it's obviously
+	 * not a permanent "solution".
+	 */
+	return True;
+#endif
+
+	cert = tls_get_certificate(net->tls);
+
+	if (!cert)
+	{
+		goto exit;
+	}
+
+	subject = crypto_cert_get_subject(cert);
+	issuer = crypto_cert_get_issuer(cert);
+	fingerprint = crypto_cert_get_fingerprint(cert);
+
+	verified = tls_verify(net->tls, net->server);
+
+	if (verified != False)
+		verified = crypto_cert_verify_peer_identity(cert, net->server);
+
+	verified = ui_check_certificate(net->rdp->inst, fingerprint, subject, issuer, verified);
+
+	xfree(fingerprint);
+	xfree(subject);
+	xfree(issuer);
+
+exit:
+	if (cert)
+	{
+		crypto_cert_free(cert);
+		cert = NULL;
+	}
+
+	return verified;
+}
+#endif
+
+RD_BOOL
+network_connect(rdpNetwork * net, char* server, char* username, int port)
+{
+	NEGO *nego = net->iso->nego;
+
+	net->port = port;
+	net->server = server;
+	net->username = username;
+	net->license->license_issued = 0;
+
+	if (net->rdp->settings->nla_security)
+		nego->enabled_protocols[PROTOCOL_NLA] = 1;
+	if (net->rdp->settings->tls_security)
+		nego->enabled_protocols[PROTOCOL_TLS] = 1;
+	if (net->rdp->settings->rdp_security)
+		nego->enabled_protocols[PROTOCOL_RDP] = 1;
+
+	if (!iso_connect(net->iso, net->server, net->username, net->port))
+		return False;
+
+#ifndef DISABLE_TLS
+	if(nego->selected_protocol & PROTOCOL_NLA)
+	{
+		/* TLS with NLA was successfully negotiated */
+
+		RD_BOOL status = 1;
+		printf("TLS encryption with NLA negotiated\n");
+		net->tls = tls_new();
+
+		if (!tls_connect(net->tls, net->tcp->sock))
+			return False;
+
+		if (!network_verify_tls(net))
+			return False;
+
+		net->sec->tls_connected = 1;
+		net->rdp->settings->encryption = 0;
+
+		if (!net->rdp->settings->autologin)
+			if (!ui_authenticate(net->rdp->inst))
+				return False;
+
+		net->credssp = credssp_new(net);
+
+		if (credssp_authenticate(net->credssp) < 0)
+		{
+			printf("Authentication failure, check credentials.\n"
+					"If credentials are valid, the NTLMSSP implementation may be to blame.\n");
+			credssp_free(net->credssp);
+			return 0;
+		}
+
+		credssp_free(net->credssp);
+
+		status = mcs_connect(net->mcs);
+		return status;
+	}
+	else if(nego->selected_protocol & PROTOCOL_TLS)
+	{
+		/* TLS without NLA was successfully negotiated */
+		RD_BOOL success;
+		printf("TLS encryption negotiated\n");
+		net->tls = tls_new();
+
+		if (!tls_connect(net->tls, net->tcp->sock))
+			return False;
+
+		if (!network_verify_tls(net))
+			return False;
+
+		net->sec->tls_connected = 1;
+		net->rdp->settings->encryption = 0;
+
+		success = mcs_connect(net->mcs);
+
+		return success;
+	}
+	else
+#endif
+	{
+		RD_BOOL success;
+
+		printf("Standard RDP encryption negotiated\n");
+
+		success = mcs_connect(net->mcs);
+
+		if (success && net->rdp->settings->encryption)
+			sec_establish_key(net->sec);
+
+		return success;
+	}
+
+	return 0;
+}
+
+void
+network_send(rdpNetwork * net, STREAM s)
+{
+#ifndef DISABLE_TLS
+	if (net->sec->tls_connected)
+	{
+		tls_write(net->tls, (char*) s->data, s->end - s->data);
+	}
+	else
+#endif
+	{
+		tcp_write(net->tcp, s);
+	}
+}
+
+STREAM
+network_recv(rdpNetwork * net, STREAM s, uint32 length)
+{
+	int rcvd = 0;
+	uint32 p_offset;
+	uint32 new_length;
+	uint32 end_offset;
+
+	if (s == NULL)
+	{
+		/* read into "new" stream */
+		if (length > net->in.size)
+		{
+			net->in.data = (uint8 *) xrealloc(net->in.data, length);
+			net->in.size = length;
+		}
+
+		net->in.end = net->in.p = net->in.data;
+		s = &(net->in);
+	}
+	else
+	{
+		/* append to existing stream */
+		new_length = (s->end - s->data) + length;
+		if (new_length > s->size)
+		{
+			p_offset = s->p - s->data;
+			end_offset = s->end - s->data;
+			s->data = (uint8 *) xrealloc(s->data, new_length);
+			s->size = new_length;
+			s->p = s->data + p_offset;
+			s->end = s->data + end_offset;
+		}
+	}
+
+	while (length > 0)
+	{
+#ifndef DISABLE_TLS
+		if (net->sec->tls_connected)
+		{
+			rcvd = tls_read(net->tls, (char*) s->end, length);
+
+			if (rcvd < 0)
+				return NULL;
+		}
+		else
+#endif
+		{
+			rcvd = tcp_read(net->tcp, (char*) s->end, length);
+		}
+
+		s->end += rcvd;
+		length -= rcvd;
+	}
+
+	return s;
+}
+
+rdpNetwork*
+network_new(rdpRdp * rdp)
+{
+	rdpNetwork * self;
+
+	self = (rdpNetwork *) xmalloc(sizeof(rdpNetwork));
+
+	if (self != NULL)
+	{
+		memset(self, 0, sizeof(rdpNetwork));
+		self->rdp = rdp;
+		self->mcs = mcs_new(self);
+		self->iso = iso_new(self);
+		self->license = license_new(self);
+
+		self->in.size = 4096;
+		self->in.data = (uint8 *) xmalloc(self->in.size);
+
+		self->out.size = 4096;
+		self->out.data = (uint8 *) xmalloc(self->out.size);
+	}
+
+	return self;
+}
+
+void
+network_free(rdpNetwork * net)
+{
+	if (net != NULL)
+	{
+		xfree(net->in.data);
+		xfree(net->out.data);
+		xfree(net);
+	}
+}

--- a/libfreerdp-core/network.h
+++ b/libfreerdp-core/network.h
@@ -40,6 +40,7 @@ struct rdp_network
 	char* username;
 	struct stream in;
 	struct stream out;
+	struct _NEGO * nego;
 	struct rdp_rdp * rdp;
 	struct rdp_tcp * tcp;
 	struct rdp_sec * sec;
@@ -51,18 +52,20 @@ struct rdp_network
 };
 typedef struct rdp_network rdpNetwork;
 
+STREAM
+network_stream_init(rdpNetwork * net, uint32 min_size);
 RD_BOOL
 network_connect(rdpNetwork * net, char* server, char* username, int port);
+void
+network_disconnect(rdpNetwork * net);
 
 void
 network_send(rdpNetwork * net, STREAM s);
-
 STREAM
 network_recv(rdpNetwork * net, STREAM s, uint32 length);
 
 rdpNetwork*
 network_new(rdpRdp * rdp);
-
 void
 network_free(rdpNetwork * net);
 

--- a/libfreerdp-core/network.h
+++ b/libfreerdp-core/network.h
@@ -40,6 +40,7 @@ struct rdp_network
 	char* username;
 	struct stream in;
 	struct stream out;
+	int tls_connected;
 	struct _NEGO * nego;
 	struct rdp_rdp * rdp;
 	struct rdp_tcp * tcp;

--- a/libfreerdp-core/network.h
+++ b/libfreerdp-core/network.h
@@ -1,0 +1,69 @@
+/*
+   FreeRDP: A Remote Desktop Protocol client.
+   Network Transport Abstraction Layer
+
+   Copyright 2011 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#ifndef __NETWORK_H
+#define __NETWORK_H
+
+#include <freerdp/freerdp.h>
+#include <freerdp/types/ui.h>
+
+#include "tcp.h"
+#include "tls.h"
+#include "iso.h"
+#include "mcs.h"
+#include "rdp.h"
+#include "secure.h"
+#include "stream.h"
+#include "credssp.h"
+#include "license.h"
+
+struct rdp_network
+{
+	int port;
+	char* server;
+	char* username;
+	struct stream in;
+	struct stream out;
+	struct rdp_rdp * rdp;
+	struct rdp_tcp * tcp;
+	struct rdp_sec * sec;
+	struct rdp_tls * tls;
+	struct rdp_iso * iso;
+	struct rdp_mcs * mcs;
+	struct rdp_credssp * credssp;
+	struct rdp_license * license;
+};
+typedef struct rdp_network rdpNetwork;
+
+RD_BOOL
+network_connect(rdpNetwork * net, char* server, char* username, int port);
+
+void
+network_send(rdpNetwork * net, STREAM s);
+
+STREAM
+network_recv(rdpNetwork * net, STREAM s, uint32 length);
+
+rdpNetwork*
+network_new(rdpRdp * rdp);
+
+void
+network_free(rdpNetwork * net);
+
+#endif /* __NETWORK_H */

--- a/libfreerdp-core/network.h
+++ b/libfreerdp-core/network.h
@@ -28,7 +28,7 @@
 #include "iso.h"
 #include "mcs.h"
 #include "rdp.h"
-#include "secure.h"
+#include "security.h"
 #include "stream.h"
 #include "credssp.h"
 #include "license.h"

--- a/libfreerdp-core/ntlmssp.h
+++ b/libfreerdp-core/ntlmssp.h
@@ -20,7 +20,7 @@
 #ifndef __NTLMSSP_H
 #define __NTLMSSP_H
 
-#include "secure.h"
+#include "security.h"
 #include "credssp.h"
 
 #include <freerdp/utils/debug.h>

--- a/libfreerdp-core/rail.c
+++ b/libfreerdp-core/rail.c
@@ -19,7 +19,7 @@
 
 #include "frdp.h"
 #include "rdp.h"
-#include "secure.h"
+#include "security.h"
 #include <freerdp/rdpset.h>
 #include <freerdp/utils/memory.h>
 

--- a/libfreerdp-core/rdp.c
+++ b/libfreerdp-core/rdp.c
@@ -1750,16 +1750,12 @@ rdp_new(struct rdp_set *settings, struct rdp_inst *inst)
 		self->buffer_size = 2048;
 		self->buffer = xmalloc(self->buffer_size);
 		memset(self->buffer, 0, self->buffer_size);
-		self->net = network_new(self);
 		self->sec = sec_new(self);
+		self->net = network_new(self);
 		self->orders = orders_new(self);
 		self->pcache = pcache_new(self);
 		self->cache = cache_new(self);
 		self->ext = ext_new(self);
-
-		self->net->rdp = self;
-		self->net->sec = self->sec;
-		self->net->tcp = self->net->iso->tcp;
 	}
 	return self;
 }

--- a/libfreerdp-core/rdp.c
+++ b/libfreerdp-core/rdp.c
@@ -36,6 +36,7 @@
 #include "ext.h"
 #include "surface.h"
 #include <freerdp/freerdp.h>
+#include <freerdp/utils/hexdump.h>
 
 #include "rdp.h"
 
@@ -1410,7 +1411,7 @@ process_redirect_pdu(rdpRdp * rdp, STREAM s)
 		rdp->redirect_routingtoken = xmalloc_in_len32_data(rdp, s,
 			&rdp->redirect_routingtoken_len);
 		printf("redirect_cookie_len: %d\n", rdp->redirect_routingtoken_len);
-		hexdump((void*)rdp->redirect_routingtoken, rdp->redirect_routingtoken_len);
+		freerdp_hexdump((uint8*)rdp->redirect_routingtoken, rdp->redirect_routingtoken_len);
 	}
 	if (redirFlags & LB_USERNAME)
 	{
@@ -1444,7 +1445,7 @@ process_redirect_pdu(rdpRdp * rdp, STREAM s)
 		rdp->redirect_target_net_addresses = xmalloc_in_len32_data(rdp, s,
 			&rdp->redirect_target_net_addresses_len);
 		printf("redirect_target_net_addresses_len: %d\n", rdp->redirect_target_net_addresses_len);
-		hexdump((void*)rdp->redirect_target_net_addresses, rdp->redirect_target_net_addresses_len);
+		freerdp_hexdump((uint8*)rdp->redirect_target_net_addresses, rdp->redirect_target_net_addresses_len);
 	}
 	if (redirFlags & LB_NOREDIRECT)
 	{

--- a/libfreerdp-core/rdp.c
+++ b/libfreerdp-core/rdp.c
@@ -26,7 +26,7 @@
 #include "iso.h"
 #include "tcp.h"
 #include "mcs.h"
-#include "secure.h"
+#include "security.h"
 #include "rail.h"
 #include "capabilities.h"
 #include "orders.h"

--- a/libfreerdp-core/rdp.c
+++ b/libfreerdp-core/rdp.c
@@ -154,7 +154,7 @@ rdp_init_data(rdpRdp * rdp, int maxlen)
 
 	uint32 sec_flags;
 
-	if (rdp->sec->tls_connected)
+	if (rdp->net->tls_connected)
 		sec_flags = 0;
 	else
 		sec_flags = rdp->settings->encryption ? SEC_ENCRYPT : 0;
@@ -765,7 +765,7 @@ rdp_send_confirm_active(rdpRdp * rdp)
 	s_mark_end(caps);
 	caplen = (int) (caps->end - caps->data);
 
-	if (rdp->sec->tls_connected)
+	if (rdp->net->tls_connected)
 		sec_flags = 0;
 	else
 		sec_flags = rdp->settings->encryption ? SEC_ENCRYPT : 0;
@@ -1043,6 +1043,7 @@ process_system_pointer_pdu(rdpRdp * rdp, STREAM s)
 
 		default:
 			ui_unimpl(rdp->inst, "Unknown System Pointer message 0x%x\n", system_pointer_type);
+			break;
 	}
 }
 
@@ -1092,6 +1093,7 @@ process_pointer_pdu(rdpRdp * rdp, STREAM s)
 
 		default:
 			ui_unimpl(rdp->inst, "Unknown Pointer message 0x%x\n", message_type);
+			break;
 	}
 }
 
@@ -1264,6 +1266,7 @@ process_update_pdu(rdpRdp * rdp, STREAM s)
 
 		default:
 			ui_unimpl(rdp->inst, "Unknown update pdu type 0x%x\n", update_type);
+			break;
 	}
 	ui_end_update(rdp->inst);
 }
@@ -1361,6 +1364,7 @@ process_data_pdu(rdpRdp * rdp, STREAM s)
 
 		default:
 			ui_unimpl(rdp->inst, "Unknown data PDU type 0x%x\n", pduType2);
+			break;
 	}
 	return False;
 }
@@ -1643,6 +1647,7 @@ rdp_loop(rdpRdp * rdp, RD_BOOL * deactivated)
 				break;
 			default:
 				ui_unimpl(rdp->inst, "Unknown PDU type 0x%x", type);
+				break;
 		}
 		if (disc)
 			return False;
@@ -1681,7 +1686,7 @@ rdp_connect(rdpRdp * rdp)
 	xfree(password_encoded);
 
 	/* by setting encryption to False here, we have an encrypted login packet but unencrypted transfer of other packets */
-	if (rdp->sec->tls_connected)
+	if (rdp->net->tls_connected)
 		rdp->settings->encryption = 0;
 
 	return True;

--- a/libfreerdp-core/rdp.h
+++ b/libfreerdp-core/rdp.h
@@ -65,11 +65,12 @@ struct rdp_rdp
 	UNICONV *uniconv;
 	RDPCOMP mppc_dict;
 	struct rdp_sec * sec;
-	struct rdp_set * settings; // RDP settings
+	struct rdp_network * net;
+	struct rdp_set * settings;
 	struct rdp_orders * orders;
 	struct rdp_pcache * pcache;
 	struct rdp_cache * cache;
-	struct rdp_app * app; // RemoteApp
+	struct rdp_app * app;
 	struct rdp_ext * ext;
 	/* Session Directory redirection */
 	int redirect;

--- a/libfreerdp-core/secure.c
+++ b/libfreerdp-core/secure.c
@@ -258,7 +258,7 @@ static void
 sec_decrypt(rdpSec * sec, uint8 * data, int length)
 {
 #ifndef DISABLE_TLS
-	if (sec->tls_connected)
+	if (sec->net->tls_connected)
 		return;
 #endif
 
@@ -462,7 +462,7 @@ sec_out_client_security_data(rdpSec * sec, rdpSet * settings, STREAM s)
 	out_uint16_le(s, UDH_CS_SECURITY);	/* User Data Header type */
 	out_uint16_le(s, 12);			/* total length */
 
-	if (settings->encryption || sec->tls_connected)
+	if (settings->encryption || sec->net->tls_connected)
 		encryptionMethods = ENCRYPTION_40BIT_FLAG | ENCRYPTION_128BIT_FLAG;
 
 	out_uint32_le(s, encryptionMethods);	/* encryptionMethods */

--- a/libfreerdp-core/secure.h
+++ b/libfreerdp-core/secure.h
@@ -51,13 +51,8 @@ struct rdp_sec
 	/* These values must be available to reset state - Session Directory */
 	int sec_encrypt_use_count;
 	int sec_decrypt_use_count;
-	struct rdp_mcs * mcs;
-	struct rdp_license * license;
 	int tls_connected;
-#ifndef DISABLE_TLS
-	struct rdp_tls * tls;
-	struct rdp_credssp * credssp;
-#endif
+	struct rdp_network * net;
 };
 
 enum sec_recv_type
@@ -95,8 +90,10 @@ STREAM
 sec_recv(rdpSec * sec, secRecvType * type);
 void
 sec_out_gcc_conference_create_request(rdpSec * sec, STREAM s);
+void
+sec_establish_key(rdpSec * sec);
 RD_BOOL
-sec_connect(rdpSec * sec, char *server, char *username, int port);
+sec_verify_tls(rdpSec * sec, const char * server);
 void
 sec_disconnect(rdpSec * sec);
 rdpSec *

--- a/libfreerdp-core/secure.h
+++ b/libfreerdp-core/secure.h
@@ -37,8 +37,9 @@ sec_global_finish(void);
 
 struct rdp_sec
 {
-	struct rdp_rdp * rdp;
 	int rc4_key_len;
+	struct rdp_rdp * rdp;
+	struct rdp_network * net;
 	CryptoRc4 rc4_decrypt_key;
 	CryptoRc4 rc4_encrypt_key;
 	uint32 server_public_key_len;
@@ -51,8 +52,6 @@ struct rdp_sec
 	/* These values must be available to reset state - Session Directory */
 	int sec_encrypt_use_count;
 	int sec_decrypt_use_count;
-	int tls_connected;
-	struct rdp_network * net;
 };
 
 enum sec_recv_type
@@ -92,8 +91,6 @@ void
 sec_out_gcc_conference_create_request(rdpSec * sec, STREAM s);
 void
 sec_establish_key(rdpSec * sec);
-RD_BOOL
-sec_verify_tls(rdpSec * sec, const char * server);
 void
 sec_disconnect(rdpSec * sec);
 rdpSec *

--- a/libfreerdp-core/security.c
+++ b/libfreerdp-core/security.c
@@ -1,0 +1,549 @@
+/*
+   FreeRDP: A Remote Desktop Protocol client.
+   Standard RDP Security
+
+   Copyright (C) Matthew Chapman 1999-2008
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "frdp.h"
+#include "mcs.h"
+#include "chan.h"
+#include "license.h"
+#include "rdp.h"
+#include "iso.h"
+#include "tcp.h"
+#include <freerdp/rdpset.h>
+#include <freerdp/utils/memory.h>
+
+#ifndef DISABLE_TLS
+#include "tls.h"
+#include "credssp.h"
+#endif
+
+#include "security.h"
+
+static RD_BOOL sec_global_initialized = False;
+
+RD_BOOL
+sec_global_init(void)
+{
+	if (!sec_global_initialized)
+	{
+		sec_global_initialized = crypto_global_init();
+	}
+	return sec_global_initialized;
+}
+
+void
+sec_global_finish(void)
+{
+	crypto_global_finish();
+	sec_global_initialized = False;
+}
+
+/* these are read only */
+static uint8 pad_54[40] = {
+	54, 54, 54, 54, 54, 54, 54, 54,
+	54, 54, 54, 54, 54, 54, 54, 54,
+	54, 54, 54, 54, 54, 54, 54, 54,
+	54, 54, 54, 54, 54, 54, 54, 54,
+	54, 54, 54, 54, 54, 54, 54, 54
+};
+
+static uint8 pad_92[48] = {
+	92, 92, 92, 92, 92, 92, 92, 92,
+	92, 92, 92, 92, 92, 92, 92, 92,
+	92, 92, 92, 92, 92, 92, 92, 92,
+	92, 92, 92, 92, 92, 92, 92, 92,
+	92, 92, 92, 92, 92, 92, 92, 92,
+	92, 92, 92, 92, 92, 92, 92, 92
+};
+
+/*
+ * 48-byte transformation used to generate master secret (6.1) and key material (6.2.2).
+ * Both SHA1 and MD5 algorithms are used.
+ */
+void
+sec_hash_48(uint8 * out, uint8 * in, uint8 * salt1, uint8 * salt2, uint8 salt)
+{
+	int i;
+	uint8 pad[4];
+	uint8 shasig[20];
+	CryptoMd5 md5;
+	CryptoSha1 sha1;
+
+	for (i = 0; i < 3; i++)
+	{
+		memset(pad, salt + i, i + 1);
+
+		sha1 = crypto_sha1_init();
+		crypto_sha1_update(sha1, pad, i + 1);
+		crypto_sha1_update(sha1, in, 48);
+		crypto_sha1_update(sha1, salt1, 32);
+		crypto_sha1_update(sha1, salt2, 32);
+		crypto_sha1_final(sha1, shasig);
+
+		md5 = crypto_md5_init();
+		crypto_md5_update(md5, in, 48);
+		crypto_md5_update(md5, shasig, 20);
+		crypto_md5_final(md5, &out[i * 16]);
+	}
+}
+
+/*
+ * 16-byte transformation used to generate export keys (6.2.2).
+ */
+void
+sec_hash_16(uint8 * out, uint8 * in, uint8 * salt1, uint8 * salt2)
+{
+	CryptoMd5 md5 = crypto_md5_init();
+	crypto_md5_update(md5, in, 16);
+	crypto_md5_update(md5, salt1, 32);
+	crypto_md5_update(md5, salt2, 32);
+	crypto_md5_final(md5, out);
+}
+
+/* Reduce key entropy from 64 to 40 bits */
+static void
+sec_make_40bit(uint8 * key)
+{
+	key[0] = 0xd1;
+	key[1] = 0x26;
+	key[2] = 0x9e;
+}
+
+/* Generate encryption keys given client and server randoms */
+void
+sec_generate_keys(rdpSec * sec, uint8 * client_random, uint8 * server_random, int rc4_key_size)
+{
+	uint8 pre_master_secret[48];
+	uint8 master_secret[48];
+	uint8 key_block[48];
+
+	/* Construct pre-master secret */
+	memcpy(pre_master_secret, client_random, 24);
+	memcpy(pre_master_secret + 24, server_random, 24);
+
+	/* Generate master secret and then key material */
+	sec_hash_48(master_secret, pre_master_secret, client_random, server_random, 'A');
+	sec_hash_48(key_block, master_secret, client_random, server_random, 'X');
+
+	/* First 16 bytes of key material is MAC secret */
+	memcpy(sec->sec_sign_key, key_block, 16);
+
+	/* Generate export keys from next two blocks of 16 bytes */
+	sec_hash_16(sec->sec_decrypt_key, &key_block[16], client_random, server_random);
+	sec_hash_16(sec->sec_encrypt_key, &key_block[32], client_random, server_random);
+
+	if (rc4_key_size == 1)
+	{
+		DEBUG_SEC("40-bit encryption enabled");
+		sec_make_40bit(sec->sec_sign_key);
+		sec_make_40bit(sec->sec_decrypt_key);
+		sec_make_40bit(sec->sec_encrypt_key);
+		sec->rc4_key_len = 8;
+	}
+	else
+	{
+		DEBUG_SEC("rc_4_key_size == %d, 128-bit encryption enabled", rc4_key_size);
+		sec->rc4_key_len = 16;
+	}
+
+	/* Save initial RC4 keys as update keys */
+	memcpy(sec->sec_decrypt_update_key, sec->sec_decrypt_key, 16);
+	memcpy(sec->sec_encrypt_update_key, sec->sec_encrypt_key, 16);
+
+	/* Initialize RC4 state arrays */
+	sec->rc4_decrypt_key = crypto_rc4_init(sec->sec_decrypt_key, sec->rc4_key_len);
+	sec->rc4_encrypt_key = crypto_rc4_init(sec->sec_encrypt_key, sec->rc4_key_len);
+}
+
+/* Output a uint32 into a buffer (little-endian) */
+void
+buf_out_uint32(uint8 * buffer, uint32 value)
+{
+	buffer[0] = (value) & 0xff;
+	buffer[1] = (value >> 8) & 0xff;
+	buffer[2] = (value >> 16) & 0xff;
+	buffer[3] = (value >> 24) & 0xff;
+}
+
+/* Generate a MAC hash (5.2.3.1), using a combination of SHA1 and MD5 */
+void
+sec_sign(uint8 * signature, int siglen, uint8 * session_key, int keylen, uint8 * data, int datalen)
+{
+	uint8 shasig[20];
+	uint8 md5sig[16];
+	uint8 lenhdr[4];
+	CryptoSha1 sha1;
+	CryptoMd5 md5;
+
+	buf_out_uint32(lenhdr, datalen);
+
+	sha1 = crypto_sha1_init();
+	crypto_sha1_update(sha1, session_key, keylen);
+	crypto_sha1_update(sha1, pad_54, 40);
+	crypto_sha1_update(sha1, lenhdr, 4);
+	crypto_sha1_update(sha1, data, datalen);
+	crypto_sha1_final(sha1, shasig);
+
+	md5 = crypto_md5_init();
+	crypto_md5_update(md5, session_key, keylen);
+	crypto_md5_update(md5, pad_92, 48);
+	crypto_md5_update(md5, shasig, 20);
+	crypto_md5_final(md5, md5sig);
+
+	memcpy(signature, md5sig, siglen);
+}
+
+/* Update an encryption key */
+static void
+sec_update(rdpSec * sec, uint8 * key, uint8 * update_key)
+{
+	uint8 shasig[20];
+	CryptoSha1 sha1;
+	CryptoMd5 md5;
+	CryptoRc4 update;
+
+	sha1 = crypto_sha1_init();
+	crypto_sha1_update(sha1, update_key, sec->rc4_key_len);
+	crypto_sha1_update(sha1, pad_54, 40);
+	crypto_sha1_update(sha1, key, sec->rc4_key_len);
+	crypto_sha1_final(sha1, shasig);
+
+	md5 = crypto_md5_init();
+	crypto_md5_update(md5, update_key, sec->rc4_key_len);
+	crypto_md5_update(md5, pad_92, 48);
+	crypto_md5_update(md5, shasig, 20);
+	crypto_md5_final(md5, key);
+
+	update = crypto_rc4_init(key, sec->rc4_key_len);
+	crypto_rc4(update, sec->rc4_key_len, key, key);
+	crypto_rc4_free(update);
+
+	if (sec->rc4_key_len == 8)
+		sec_make_40bit(key);
+}
+
+/* Encrypt data using RC4 */
+static void
+sec_encrypt(rdpSec * sec, uint8 * data, int length)
+{
+	if (sec->sec_encrypt_use_count == 4096)
+	{
+		sec_update(sec, sec->sec_encrypt_key, sec->sec_encrypt_update_key);
+		crypto_rc4_free(sec->rc4_encrypt_key);
+		sec->rc4_encrypt_key = crypto_rc4_init(sec->sec_encrypt_key, sec->rc4_key_len);
+		sec->sec_encrypt_use_count = 0;
+	}
+
+	crypto_rc4(sec->rc4_encrypt_key, length, data, data);
+	sec->sec_encrypt_use_count++;
+}
+
+/* Decrypt data using RC4 */
+static void
+sec_decrypt(rdpSec * sec, uint8 * data, int length)
+{
+	if (sec->sec_decrypt_use_count == 4096)
+	{
+		sec_update(sec, sec->sec_decrypt_key, sec->sec_decrypt_update_key);
+		crypto_rc4_free(sec->rc4_decrypt_key);
+		sec->rc4_decrypt_key = crypto_rc4_init(sec->sec_decrypt_key, sec->rc4_key_len);
+		sec->sec_decrypt_use_count = 0;
+	}
+
+	crypto_rc4(sec->rc4_decrypt_key, length, data, data);
+	sec->sec_decrypt_use_count++;
+}
+
+/* Initialize secure transport packet */
+STREAM
+sec_init(rdpSec * sec, uint32 flags, int maxlen)
+{
+	STREAM s;
+	int hdrlen;
+
+	if (flags)
+	{
+		if (!(sec->net->license->license_issued))
+			hdrlen = (flags & SEC_ENCRYPT) ? 12 : 4;
+		else
+			hdrlen = (flags & SEC_ENCRYPT) ? 12 : 0;
+	}
+	else
+		hdrlen = 0;
+
+	s = mcs_init(sec->net->mcs, maxlen + hdrlen);
+	s_push_layer(s, sec_hdr, hdrlen);
+
+	return s;
+}
+
+/* Initialize fast path secure transport packet */
+STREAM
+sec_fp_init(rdpSec * sec, uint32 flags, int maxlen)
+{
+	STREAM s;
+	int hdrlen;
+
+	hdrlen = (flags & SEC_ENCRYPT) ? 8 : 0;
+	s = mcs_fp_init(sec->net->mcs, maxlen + hdrlen);
+	s_push_layer(s, sec_hdr, hdrlen);
+
+	return s;
+}
+
+/* Transmit secure transport packet over specified channel */
+void
+sec_send_to_channel(rdpSec * sec, STREAM s, uint32 flags, uint16 channel)
+{
+	int datalen;
+	s_pop_layer(s, sec_hdr);
+
+	if (flags)
+	{
+		/* Basic Security Header */
+		if (!(sec->net->license->license_issued) || (flags & SEC_ENCRYPT))
+			out_uint32_le(s, flags); /* flags */
+
+		if (flags & SEC_ENCRYPT)
+		{
+			flags &= ~SEC_ENCRYPT;
+			datalen = s->end - s->p - 8;
+
+#if WITH_DEBUG
+			DEBUG_SEC("Sending encrypted packet:");
+			hexdump(s->p + 8, datalen);
+#endif
+
+			sec_sign(s->p, 8, sec->sec_sign_key, sec->rc4_key_len, s->p + 8, datalen);
+			sec_encrypt(sec, s->p + 8, datalen);
+		}
+	}
+
+	mcs_send_to_channel(sec->net->mcs, s, channel);
+}
+
+/* Transmit secure transport packet */
+
+void
+sec_send(rdpSec * sec, STREAM s, uint32 flags)
+{
+	sec_send_to_channel(sec, s, flags, MCS_GLOBAL_CHANNEL);
+}
+
+/* Transmit secure fast path packet */
+void
+sec_fp_send(rdpSec * sec, STREAM s, uint32 flags)
+{
+	int datalen;
+	s_pop_layer(s, sec_hdr);
+	if (flags & SEC_ENCRYPT)
+	{
+		datalen = ((int) (s->end - s->p)) - 8;
+		sec_sign(s->p, 8, sec->sec_sign_key, sec->rc4_key_len, s->p + 8, datalen);
+		sec_encrypt(sec, s->p + 8, datalen);
+	}
+	mcs_fp_send(sec->net->mcs, s, flags);
+}
+
+/* Transfer the client random to the server */
+void
+sec_establish_key(rdpSec * sec)
+{
+	uint32 length = sec->server_public_key_len + SEC_PADDING_SIZE;
+	uint32 flags = SEC_EXCHANGE_PKT;
+	STREAM s;
+
+	s = sec_init(sec, flags, length + 4);
+
+	out_uint32_le(s, length);
+	out_uint8p(s, sec->sec_crypted_random, sec->server_public_key_len);
+	out_uint8s(s, SEC_PADDING_SIZE);
+
+	s_mark_end(s);
+	sec_send(sec, s, flags);
+}
+
+void
+sec_reverse_copy(uint8 * out, uint8 * in, int len)
+{
+	int i;
+	in += len;
+	for (i = 0; i < len; i++)
+	{
+		*out++ = *--in;
+	}
+}
+
+/* Parse a Server Proprietary Certificate RSA Public Key */
+RD_BOOL
+sec_parse_public_key(rdpSec * sec, STREAM s, uint32 len, uint8 * modulus, uint8 * exponent)
+{
+	uint32 magic;
+	uint32 modulus_len;
+
+	in_uint32_le(s, magic);
+	if (magic != SEC_RSA_MAGIC)
+	{
+		ui_error(sec->rdp->inst, "RSA magic 0x%x\n", magic);
+		return False;
+	}
+
+	in_uint32_le(s, modulus_len);
+	if (4 + 4 + 4 + 4 + SEC_EXPONENT_SIZE + modulus_len != len)
+	{
+		ui_error(sec->rdp->inst, "Inconsistent Server Proprietary Certificate public key size\n");
+		return False;
+	}
+	modulus_len -= SEC_PADDING_SIZE;
+	if ((modulus_len < SEC_MODULUS_SIZE) || (modulus_len > SEC_MAX_MODULUS_SIZE))
+	{
+		ui_error(sec->rdp->inst, "Bad Server Proprietary Certificate public key size (%u bits)\n", modulus_len * 8);
+		return False;
+	}
+
+	in_uint8s(s, 4);	/* modulus_bits - must match modulus_len */
+	in_uint8s(s, 4);	/* datalen - how much data can be encoded */
+	sec_reverse_copy(exponent, s->p, SEC_EXPONENT_SIZE);
+	in_uint8s(s, SEC_EXPONENT_SIZE);
+	sec_reverse_copy(modulus, s->p, modulus_len);
+	in_uint8s(s, modulus_len);
+	in_uint8s(s, SEC_PADDING_SIZE);	/* zero padding - included in modulus_len but not in modulus_bits */
+	sec->server_public_key_len = modulus_len;
+
+	return s_check(s);
+}
+
+/* Parse a Proprietary Certificate signature */
+RD_BOOL
+sec_parse_public_sig(STREAM s, uint32 len)
+{
+	/* The Proprietary Certificate signature uses a static published private key.
+	 * That is completely nonsense, so we won't bother checking it. */
+
+	in_uint8s(s, len);
+	return len == 72;
+}
+
+/* Receive secure transport packet
+ * Some package types are processed internally.
+ * If s is returned a package of *type must be processed by the caller */
+STREAM
+sec_recv(rdpSec * sec, secRecvType * type)
+{
+	STREAM s;
+	uint16 channel;
+	uint32 sec_flags;
+	isoRecvType iso_type;
+
+	while ((s = mcs_recv(sec->net->mcs, &iso_type, &channel)) != NULL)
+	{
+		if ((iso_type == ISO_RECV_FAST_PATH) ||
+			(iso_type == ISO_RECV_FAST_PATH_ENCRYPTED))
+		{
+			*type = SEC_RECV_FAST_PATH;
+			if (iso_type == ISO_RECV_FAST_PATH_ENCRYPTED)
+			{
+				in_uint8s(s, 8);	/* dataSignature */ /* TODO: Check signature! */
+				sec_decrypt(sec, s->p, s->end - s->p);
+			}
+			return s;
+		}
+		if (iso_type != ISO_RECV_X224)
+		{
+			ui_error(sec->rdp->inst, "expected ISO_RECV_X224, got %d\n", iso_type);
+			return NULL;
+		}
+		if (sec->rdp->settings->encryption || !sec->net->license->license_issued)
+		{
+			/* basicSecurityHeader: */
+			in_uint32_le(s, sec_flags);
+
+			if ((sec_flags & SEC_ENCRYPT) || (sec_flags & SEC_REDIRECTION_PKT))
+			{
+				in_uint8s(s, 8);	/* dataSignature */ /* TODO: Check signature! */
+				sec_decrypt(sec, s->p, s->end - s->p);
+			}
+
+			if (sec_flags & SEC_LICENSE_PKT)
+			{
+				*type = SEC_RECV_LICENSE;
+				license_process(sec->net->license, s);
+				continue;
+			}
+
+			if (sec_flags & SEC_REDIRECTION_PKT)
+			{
+				*type = SEC_RECV_REDIRECT;
+				return s;
+			}
+		}
+
+		if (channel != MCS_GLOBAL_CHANNEL)
+		{
+			vchan_process(sec->net->mcs->chan, s, channel);
+			*type = SEC_RECV_IOCHANNEL;
+			return s;
+		}
+		*type = SEC_RECV_SHARE_CONTROL;
+		return s;
+	}
+
+	return NULL;
+}
+
+/* Disconnect a connection */
+void
+sec_disconnect(rdpSec * sec)
+{
+	mcs_disconnect(sec->net->mcs);
+
+	if (sec->rc4_decrypt_key)
+		crypto_rc4_free(sec->rc4_decrypt_key);
+	sec->rc4_decrypt_key = NULL;
+	if (sec->rc4_encrypt_key)
+		crypto_rc4_free(sec->rc4_encrypt_key);
+	sec->rc4_encrypt_key = NULL;
+}
+
+rdpSec *
+sec_new(struct rdp_rdp * rdp)
+{
+	rdpSec * self;
+
+	self = (rdpSec *) xmalloc(sizeof(rdpSec));
+	if (self != NULL)
+	{
+		memset(self, 0, sizeof(rdpSec));
+		self->rdp = rdp;
+		self->rc4_decrypt_key = NULL;
+		self->rc4_encrypt_key = NULL;
+		self->net = rdp->net;
+	}
+	return self;
+}
+
+void
+sec_free(rdpSec * sec)
+{
+	if (sec != NULL)
+	{
+		license_free(sec->net->license);
+		mcs_free(sec->net->mcs);
+		xfree(sec);
+	}
+}

--- a/libfreerdp-core/security.h
+++ b/libfreerdp-core/security.h
@@ -1,6 +1,6 @@
 /*
    FreeRDP: A Remote Desktop Protocol client.
-   Protocol services - RDP encryption and licensing
+   Standard RDP Security
 
    Copyright (C) Jay Sorg 2009-2011
 
@@ -17,8 +17,8 @@
    limitations under the License.
 */
 
-#ifndef __SECURE_H
-#define __SECURE_H
+#ifndef __SECURITY_H
+#define __SECURITY_H
 
 typedef struct rdp_sec rdpSec;
 
@@ -73,6 +73,12 @@ buf_out_uint32(uint8 * buffer, uint32 value);
 void
 sec_sign(uint8 * signature, int siglen, uint8 * session_key, int keylen,
 	 uint8 * data, int datalen);
+RD_BOOL
+sec_parse_public_key(rdpSec * sec, STREAM s, uint32 len, uint8 * modulus, uint8 * exponent);
+RD_BOOL
+sec_parse_public_sig(STREAM s, uint32 len);
+void
+sec_generate_keys(rdpSec * sec, uint8 * client_random, uint8 * server_random, int rc4_key_size);
 STREAM
 sec_init(rdpSec * sec, uint32 flags, int maxlen);
 STREAM
@@ -84,11 +90,11 @@ sec_send(rdpSec * sec, STREAM s, uint32 flags);
 void
 sec_fp_send(rdpSec * sec, STREAM s, uint32 flags);
 void
-sec_process_mcs_data(rdpSec * sec, STREAM s);
+sec_reverse_copy(uint8 * out, uint8 * in, int len);
+void
+connect_process_mcs_data(rdpSec * sec, STREAM s);
 STREAM
 sec_recv(rdpSec * sec, secRecvType * type);
-void
-sec_out_gcc_conference_create_request(rdpSec * sec, STREAM s);
 void
 sec_establish_key(rdpSec * sec);
 void

--- a/libfreerdp-core/security.h
+++ b/libfreerdp-core/security.h
@@ -91,6 +91,10 @@ void
 sec_fp_send(rdpSec * sec, STREAM s, uint32 flags);
 void
 sec_reverse_copy(uint8 * out, uint8 * in, int len);
+RD_BOOL
+sec_parse_cert_chain_v1(rdpSec * sec, STREAM s, uint8 * modulus, uint8 * exponent);
+RD_BOOL
+sec_parse_cert_chain_v2(rdpSec * sec, STREAM s, uint8 * modulus, uint8 * exponent);
 void
 connect_process_mcs_data(rdpSec * sec, STREAM s);
 STREAM

--- a/libfreerdp-core/surface.c
+++ b/libfreerdp-core/surface.c
@@ -21,6 +21,7 @@
 #include "rdp.h"
 #include "stream.h"
 #include <freerdp/freerdp.h>
+#include <freerdp/utils/hexdump.h>
 
 #include "surface.h"
 
@@ -83,7 +84,7 @@ surface_codec_cap(rdpRdp * rdp, uint8 * codec_guid, int codec_id,
 	else
 	{
 		//printf("unknown guid\n");
-		hexdump(codec_guid, 16);
+		freerdp_hexdump(codec_guid, 16);
 	}
 	return s;
 }

--- a/libfreerdp-core/tcp.c
+++ b/libfreerdp-core/tcp.c
@@ -32,7 +32,6 @@
 #include "frdp.h"
 #include "iso.h"
 #include "mcs.h"
-#include "secure.h"
 #include "rdp.h"
 #include <freerdp/utils/memory.h>
 #include <freerdp/utils/hexdump.h>

--- a/libfreerdp-core/tcp.h
+++ b/libfreerdp-core/tcp.h
@@ -27,11 +27,9 @@
 struct rdp_tcp
 {
 	int sock;
-	struct rdp_iso * iso;
-	int tcp_port_rdp;
 	char ipaddr[32];
-	struct stream in;
-	struct stream out;
+	int tcp_port_rdp;
+	struct rdp_network * net;
 #ifdef _WIN32
 	WSAEVENT wsa_event;
 #endif
@@ -47,12 +45,6 @@ RD_BOOL
 tcp_can_send(int sck, int millis);
 RD_BOOL
 tcp_can_recv(int sck, int millis);
-STREAM
-tcp_init(rdpTcp * tcp, uint32 minsize);
-void
-tcp_send(rdpTcp * tcp, STREAM s);
-STREAM
-tcp_recv(rdpTcp * tcp, STREAM s, uint32 length);
 RD_BOOL
 tcp_connect(rdpTcp * tcp, char * server, int port);
 void
@@ -60,7 +52,7 @@ tcp_disconnect(rdpTcp * tcp);
 char *
 tcp_get_address(rdpTcp * tcp);
 rdpTcp *
-tcp_new(struct rdp_iso * iso);
+tcp_new(struct rdp_network * net);
 void
 tcp_free(rdpTcp * tcp);
 

--- a/libfreerdp-core/tcp.h
+++ b/libfreerdp-core/tcp.h
@@ -26,7 +26,7 @@
 
 struct rdp_tcp
 {
-	int sock;
+	int sockfd;
 	char ipaddr[32];
 	int tcp_port_rdp;
 	struct rdp_network * net;
@@ -37,7 +37,7 @@ struct rdp_tcp
 typedef struct rdp_tcp rdpTcp;
 
 void
-tcp_write(rdpTcp * tcp, STREAM s);
+tcp_write(rdpTcp * tcp, char* b, int length);
 int
 tcp_read(rdpTcp * tcp, char* b, int length);
 

--- a/libfreerdp-core/tcp.h
+++ b/libfreerdp-core/tcp.h
@@ -28,15 +28,20 @@ struct rdp_tcp
 {
 	int sock;
 	struct rdp_iso * iso;
-	struct stream in;
-	struct stream out;
 	int tcp_port_rdp;
 	char ipaddr[32];
+	struct stream in;
+	struct stream out;
 #ifdef _WIN32
 	WSAEVENT wsa_event;
 #endif
 };
 typedef struct rdp_tcp rdpTcp;
+
+void
+tcp_write(rdpTcp * tcp, STREAM s);
+int
+tcp_read(rdpTcp * tcp, char* b, int length);
 
 RD_BOOL
 tcp_can_send(int sck, int millis);

--- a/libfreerdp-utils/Makefile.am
+++ b/libfreerdp-utils/Makefile.am
@@ -13,7 +13,8 @@ libfreerdp_utils_la_SOURCES = \
 	wait_obj.c \
 	chan_plugin.c \
 	stopwatch.c \
-	profiler.c
+	profiler.c \
+	hexdump.c
 
 libfreerdp_utils_la_CFLAGS = \
 	-I$(top_srcdir) \

--- a/libfreerdp-utils/hexdump.c
+++ b/libfreerdp-utils/hexdump.c
@@ -1,0 +1,56 @@
+/*
+   FreeRDP: A Remote Desktop Protocol client.
+   Hex Dump Utils
+
+   Copyright 2011 Marc-Andre Moreau <marcandre.moreau@gmail.com>
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include <stdio.h>
+#include <string.h>
+
+#include <freerdp/types/base.h>
+
+#include <freerdp/utils/hexdump.h>
+
+void freerdp_hexdump(uint8* data, int length)
+{
+	uint8* p = data;
+	int i, line, offset = 0;
+
+	while (offset < length)
+	{
+		printf("%04x ", offset);
+
+		line = length - offset;
+
+		if (line > FREERDP_HEXDUMP_LINE_LENGTH)
+			line = FREERDP_HEXDUMP_LINE_LENGTH;
+
+		for (i = 0; i < line; i++)
+			printf("%02x ", p[i]);
+
+		for (; i < FREERDP_HEXDUMP_LINE_LENGTH; i++)
+			printf("   ");
+
+		for (i = 0; i < line; i++)
+			printf("%c", (p[i] >= 0x20 && p[i] < 0x7F) ? p[i] : '.');
+
+		printf("\n");
+
+		offset += line;
+		p += line;
+	}
+}
+


### PR DESCRIPTION
Long overdue refactoring of core protocol layers:

decoupling tcp from tls encryption
decoupling secure.c from iso, mcs, tcp, tls
abstracting transport layer in new "network" module

secure.c was basically coupled with everything, and with the inclusion of TLS and NLA support, it was getting very ugly. When Standard RDP security is not in use, we should not use data structured logically related to it, or worse, encapsulated in it.

Another thing which I'd like to do is remove a lot of the connection sequence packets out of secure.c, such that secure.c contains only the encryption code for Standard RDP encryption, nothing else.
