### PR TITLE
libfreerdp-chanman: use platform independent semaphores

### DIFF
--- a/include/freerdp/utils/semaphore.h
+++ b/include/freerdp/utils/semaphore.h
@@ -23,5 +23,6 @@
 void freerdp_sem_create(void * sem_struct, int iv);
 void freerdp_sem_signal(void * sem_struct);
 void freerdp_sem_wait(void * sem_struct);
+void freerdp_sem_destroy(void * sem_struct);
 
 #endif /* __SEMAPHORE_UTILS_H */

--- a/libfreerdp-chanman/libchanman.c
+++ b/libfreerdp-chanman/libchanman.c
@@ -56,6 +56,7 @@
 #else
 #include <dlfcn.h>
 #include <semaphore.h>
+#include <freerdp/utils/semaphore.h>
 #include <netdb.h>
 #include <unistd.h>
 #include <pthread.h>
@@ -65,10 +66,10 @@
 #define MUTEX_UNLOCK(m) pthread_mutex_unlock(&m)
 #define MUTEX_DESTROY(m) pthread_mutex_destroy(&m)
 #define SEMAPHORE sem_t
-#define SEMAPHORE_INIT(s, i, m) sem_init(&s, i, m)
-#define SEMAPHORE_WAIT(s) sem_wait(&s)
-#define SEMAPHORE_POST(s) sem_post(&s)
-#define SEMAPHORE_DESTROY(s) sem_destroy(&s)
+#define SEMAPHORE_INIT(s, m) freerdp_sem_create(&(s), (m))
+#define SEMAPHORE_WAIT(s) freerdp_sem_wait(&(s))
+#define SEMAPHORE_POST(s) freerdp_sem_signal(&(s))
+#define SEMAPHORE_DESTROY(s) freerdp_sem_destroy(&(s))
 #define CHR char
 #define DLOPEN(f) dlopen(f, RTLD_LOCAL | RTLD_LAZY)
 #define DLSYM(f, n) dlsym(f, n)
@@ -652,8 +653,8 @@ freerdp_chanman_new(void)
 	chan_man = (rdpChanMan *) malloc(sizeof(rdpChanMan));
 	memset(chan_man, 0, sizeof(rdpChanMan));
 
-	SEMAPHORE_INIT(chan_man->sem, 0, 1); /* start at 1 */
-	SEMAPHORE_INIT(chan_man->sem_event, 0, 1); /* start at 1 */
+	SEMAPHORE_INIT(chan_man->sem,1); /* start at 1 */
+	SEMAPHORE_INIT(chan_man->sem_event, 1); /* start at 1 */
 #ifdef _WIN32
 	chan_man->chan_event = CreateEvent(NULL, TRUE, FALSE, NULL);
 #else

--- a/libfreerdp-utils/semaphore.c
+++ b/libfreerdp-utils/semaphore.c
@@ -37,6 +37,15 @@ void freerdp_sem_create(void * sem_struct, int iv)
 #endif
 }
 
+void freerdp_sem_destroy(void * sem_struct)
+{
+#ifdef __APPLE__
+	semaphore_destroy(mach_task_self(), *((semaphore_t *)sem_struct));
+#else
+	sem_destroy((sem_t *)sem_struct);
+#endif
+}
+
 void freerdp_sem_signal(void * sem_struct)
 {
 #ifdef __APPLE__


### PR DESCRIPTION
old description follows:
-libchanman.c used semaphores to synchronize writing of data
to stream. However, these were value-1, logically equivilant
to mutexes. Because Mac OS X doesn't support unnamed semaphores,
it is reasonable and beneficial to simply replace these
semaphores with mutexes. This makes rdpdr work on OS X, when it
previously didn't, and works fine on Linux.-
